### PR TITLE
Highlight field errors in generation when they happen

### DIFF
--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -40,7 +40,7 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields) (*Gener
 	templateFns["generate"] = func(field string) interface{} {
 		bindF, ok := fieldMap[field]
 		if !ok {
-			return ""
+			return "<missing field>"
 		}
 
 		value, err := bindF(state, nil)

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -45,7 +45,7 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields) (*Gener
 
 		value, err := bindF(state, nil)
 		if err != nil {
-			return ""
+			return "<unvalued field>"
 		}
 		return value
 	}

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -45,7 +45,7 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields) (*Gener
 
 		value, err := bindF(state, nil)
 		if err != nil {
-			return "<unvalued field>"
+			return ""
 		}
 		return value
 	}

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -6,6 +6,7 @@ package genlib
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/Masterminds/sprig/v3"
 	"text/template"
 	"time"
@@ -40,7 +41,7 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields) (*Gener
 	templateFns["generate"] = func(field string) interface{} {
 		bindF, ok := fieldMap[field]
 		if !ok {
-			return "<missing field>"
+			panic(fmt.Errorf("missing field: '%s' (is it present in fields.yml?)", field))
 		}
 
 		value, err := bindF(state, nil)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -364,12 +364,7 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 		t.Errorf("Expected map size 1, got %d", len(m))
 	}
 
-	v, ok := m[fld.Name]
-
-	if !ok {
-		t.Errorf("Missing key %v", fld.Name)
-
-	}
+	v, _ := m[fld.Name]
 
 	return v
 }
@@ -382,4 +377,19 @@ func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, temp
 	}
 
 	return g, NewGenState()
+}
+
+func Test_PanicOnMissingField(t *testing.T) {
+	fld := Field{}
+
+	template := []byte(`{"alpha":"{{generate "alpha"}}"}`)
+	t.Logf("with template: %s", string(template))
+
+	defer func() {
+		r := recover()
+		t.Log(r)
+	}()
+	a := testSingleTWithTextTemplate[string](t, fld, nil, template)
+	fmt.Printf("a: %s\n", a)
+	t.Errorf("should have triggered a panic")
 }


### PR DESCRIPTION
This PR aims at helping template developers in 2 situations:
1. when using `generate` on a missing field
2. when an error occurs when generating data for a field

In case `generate()` is being used in the template on a missing field
the current behaviour of returning an empty string hides the problem to
the template developer.

As it is not expected for the template to try generating a missing
field, this commit returns a known string highlighting the problem.

In case there in an error in the bind function for generating a value
for a field, instead of returning an empty string, return a fixed known
string that highlight the issue.