### PR TITLE
Enable all sprig functions in templates

### DIFF
--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -31,7 +31,7 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields) (*Gener
 
 	state := NewGenState()
 
-	templateFns := sprig.HermeticTxtFuncMap()
+	templateFns := sprig.TxtFuncMap()
 
 	templateFns["timeDuration"] = func(duration int64) time.Duration {
 		return time.Duration(duration)


### PR DESCRIPTION
Non hermetic functions are defined as "impure" functions. The list is
available here: https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/functions.go#L70

We enable them mainly due to date related functions that are very
beneficial to template developers.
