### PR TITLE
Run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/go-ucfg v0.8.6
-	github.com/elastic/go-ucfg v0.8.5
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.6.1


### PR DESCRIPTION
Go toolchain is complaining of an untidy `go.mod` file.

This PR address this (and should fix all also other PRs where CI fails with this behaviour).
