### PR TITLE
Improve Go text/template helpers docs

### DIFF
--- a/docs/go-text-template-helpers.md
+++ b/docs/go-text-template-helpers.md
@@ -1,0 +1,18 @@
+This file documents helper functions available when using the Go `text/template` template engine.
+
+Within this template is possible to use **all** helpers from [`mastermings/sprig`](https://masterminds.github.io/sprig/).
+
+<!-- helpers MUST be alphabetically sorted -->
+
+# `timeDuration`
+
+The helper accepts an `int64` and returns the equivalent `time.Duration`.
+
+**Example**:
+
+```text
+{{$timeDuration := timeDuration 5000000000}}{{$timeDuration}}
+```
+```text
+5s
+```

--- a/docs/go-text-template-helpers.md
+++ b/docs/go-text-template-helpers.md
@@ -4,6 +4,21 @@ Within this template is possible to use **all** helpers from [`mastermings/sprig
 
 <!-- helpers MUST be alphabetically sorted -->
 
+# `awsAZFromRegion`
+
+This helper accepts a string representing an AWS region (es. `us-east-1`) and returns a valid Availability Zone from that AWS region.
+
+_NOTE_: Not all regions are supported at the moment (but can be added at need). For supported regions look [here](https://github.com/elastic/elastic-integration-corpus-generator-tool/blob/2c64e07461467aef4faacd5eb41efc3b0399c270/pkg/genlib/generator_with_text_template.go#L28-L30)
+
+**Example**:
+
+```text
+{{ awsAZFromRegion "us-east-1" }}
+```
+```text
+us-east-1a
+```
+
 # `timeDuration`
 
 The helper accepts an `int64` and returns the equivalent `time.Duration`.

--- a/docs/writing-templates.md
+++ b/docs/writing-templates.md
@@ -76,11 +76,6 @@ This is equivalent to the following when using the `placeholder` template type:
 {{ .Field1 }}
 ```
 
-#### sprig functions
-The template loads the functions provided by sprig (https://masterminds.github.io/sprig/) with the exclusion of the functions are not guaranteed to evaluate to the same result for given input (https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/functions.go#L68-L95)
+#### Helpers
 
-#### "timeDuration" function
-The template provides a function named "timeDuration" that accept an int64 and return equivalent `time.Duration`, for example the following will render `5s`:
-```text
-{{$timeDuration := timeDuration 5000000000}}{{$timeDuration}} 
-```
+This template type supports other [helper functions](./go-text-template-helpers.md).


### PR DESCRIPTION
Following https://github.com/elastic/elastic-integration-corpus-generator-tool/pull/43 a new helper has been added for Go `text/template` template engine.

To help with documenting those helpers this PR moves them to a separate file and adds `awsAZFromRegion` documentation.
