### PR TITLE
Fix aws az from region

### DIFF
--- a/assets/templates/aws.billing/schema-b/gotext.tpl
+++ b/assets/templates/aws.billing/schema-b/gotext.tpl
@@ -3,8 +3,9 @@
 {{- $period := generate "metricset.period" }}
 {{- $cloudId := generate "cloud.account.id" }}
 {{- $cloudRegion := generate "cloud.region" }}
+{{- $timestamp := generate "timestamp" }}
 {
-    "@timestamp": "{{generate "timestamp"}}",
+    "@timestamp": "{{$timestamp.Format "2006-01-02T15:04:05.999999Z07:00"}}",
     "cloud": {
         "provider": "aws",
         "region": "{{$cloudRegion}}",

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-  "math/rand"
+	"math/rand"
 	"text/template"
 	"time"
 
@@ -50,7 +50,7 @@ var awsAZs map[string][]string = map[string][]string{
 	"us-west-2":      {"us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"},
 }
 
-func calculateTotEventsWithTextTemplate(totSize uint64, fieldMap map[string]any, errChan chan error, tpl []byte) (uint64, error) {
+func calculateTotEventsWithTextTemplate(totSize uint64, fieldMap map[string]any, errChan chan error, tpl []byte, templateFns template.FuncMap) (uint64, error) {
 	if totSize == 0 {
 		return 0, nil
 	}
@@ -58,12 +58,6 @@ func calculateTotEventsWithTextTemplate(totSize uint64, fieldMap map[string]any,
 	// Generate a single event to calculate the total number of events based on its size
 	t := template.New("estimate_tot_events")
 	t = t.Option("missingkey=error")
-
-	templateFns := sprig.TxtFuncMap()
-
-	templateFns["timeDuration"] = func(duration int64) time.Duration {
-		return time.Duration(duration)
-	}
 
 	templateFns["generate"] = func(field string) any {
 		state := NewGenState()
@@ -127,21 +121,13 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totSize
 
 	errChan := make(chan error)
 
-	totEvents, err := calculateTotEventsWithTextTemplate(totSize, fieldMap, errChan, tpl)
-	if err != nil {
-		return nil, err
-	}
-
-	t := template.New("generator")
-	t = t.Option("missingkey=error")
-
 	templateFns := sprig.TxtFuncMap()
 
 	templateFns["timeDuration"] = func(duration int64) time.Duration {
 		return time.Duration(duration)
 	}
-  
-  templateFns["awsAZFromRegion"] = func(region string) string {
+
+	templateFns["awsAZFromRegion"] = func(region string) string {
 		azs, ok := awsAZs[region]
 		if !ok {
 			return "NoAZ"
@@ -159,6 +145,14 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totSize
 
 		return bindF(state)
 	}
+
+	totEvents, err := calculateTotEventsWithTextTemplate(totSize, fieldMap, errChan, tpl, templateFns)
+	if err != nil {
+		return nil, err
+	}
+
+	t := template.New("generator")
+	t = t.Option("missingkey=error")
 
 	parsedTpl, err := t.Funcs(templateFns).Parse(string(tpl))
 	if err != nil {

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -58,8 +58,12 @@ func calculateTotEventsWithTextTemplate(totSize uint64, fieldMap map[string]any,
 	// Generate a single event to calculate the total number of events based on its size
 	t := template.New("estimate_tot_events")
 	t = t.Option("missingkey=error")
+	tempTemplateFns := template.FuncMap{}
+	for k, v := range templateFns {
+		tempTemplateFns[k] = v
+	}
 
-	templateFns["generate"] = func(field string) any {
+	tempTemplateFns["generate"] = func(field string) any {
 		state := NewGenState()
 		state.prevCacheForDup[field] = make(map[any]struct{})
 		state.prevCacheCardinality[field] = make([]any, 0)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -86,7 +86,7 @@ func test_CardinalityTWithTextTemplate[T any](t *testing.T, ty string) {
 		}
 
 		nSpins := 16384
-		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, 0)
+		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(len(template)*nSpins*1024))
 
 		vmapAlpha := make(map[any]int)
 		vmapBeta := make(map[any]int)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -86,7 +86,7 @@ func test_CardinalityTWithTextTemplate[T any](t *testing.T, ty string) {
 		}
 
 		nSpins := 16384
-		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(len(template)*nSpins*1024))
+		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, 0)
 
 		vmapAlpha := make(map[any]int)
 		vmapBeta := make(map[any]int)


### PR DESCRIPTION
Bugfix: `awsAZFromRegion` was not available to the template used for generating the total events

now we have a single `template.FuncMap` that's passed around