### PR TITLE
Fuzziness as float and range constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,12 @@ It is possible to tweak the randomness of the generated data through a config fi
 ##### Sample config
 ```yaml
 - name: aws.dynamodb.metrics.AccountMaxReads.max
-  fuzziness:
-    numerator: 1
-    denominator: 10
+  fuzziness: 0.1
   range:
     min: 0
     max: 100
 - name: aws.dynamodb.metrics.AccountMaxTableLevelReads.max
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
   range:
     min: 0
     max: 50
@@ -225,9 +221,7 @@ It is possible to tweak the randomness of the generated data through a config fi
     numerator: 1
     denominator: 20
 - name: aws.dynamodb.metrics.AccountProvisionedReadCapacityUtilization.avg
-  fuzziness:
-    numerator: 1
-    denominator: 10
+  fuzziness: 0.1
 - name: aws.cloudwatch.namespace
   cardinality:
     numerator: 1
@@ -254,7 +248,7 @@ It is possible to tweak the randomness of the generated data through a config fi
 The config file is a yaml file consisting of an array of config entry.
 For each config entry the following fields are available
 - `name` *mandatory*: dotted path field
-- `fuzziness` *optional (`long` and `double` type only)*: delta from the previous generated value for the same field, expressed as a ratio between a `numerator` and a `denominator`
+- `fuzziness` *optional (`long` and `double` type only)*: maximum delta from the previous generated value for the same field, expressed as float where 1 = 100%
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
 - `cardinality` *optional*: distribution of different values for the field, expressed as a ratio between a `numerator` and a `denominator`
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type. if not specified a random number of field names will be generated in the object filed type.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ It is possible to tweak the randomness of the generated data through a config fi
 The config file is a yaml file consisting of an array of config entry.
 For each config entry the following fields are available
 - `name` *mandatory*: dotted path field
-- `fuzziness` *optional (`long` and `double` type only)*: maximum delta from the previous generated value for the same field, expressed as float where 1 = 100%
+- `fuzziness` *optional (`long` and `double` type only)*: when generating data you could want generated values to change in a known interval. Fuzziness allow to specify the maximum delta a generated value can have from the previous value (for the same field), as a delta percentage; value must be between 0.0 and 1.0, where 0 is 0% and 1 is 100%. When not specified there is no constraint on the generated values, boundaries will be defined by the underlying field type
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
 - `cardinality` *optional*: distribution of different values for the field, expressed as a ratio between a `numerator` and a `denominator`
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type. if not specified a random number of field names will be generated in the object filed type.

--- a/assets/templates/aws.billing/schema-b/configs.yml
+++ b/assets/templates/aws.billing/schema-b/configs.yml
@@ -32,45 +32,32 @@
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
+  fuzziness: 0.2
 - name: aws.billing.AmortizedCost.amount
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
+  fuzziness: 0.2
 - name: aws.billing.BlendedCost.amount
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
+  fuzziness: 0.2
 - name: aws.billing.NormalizedUsageAmount.amount
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
+  fuzziness: 0.2
 - name: aws.billing.UnblendedCost.amount
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
+  fuzziness: 0.2
 - name: aws.billing.UsageQuantity.amount
   cardinality:
     numerator: 1
     denominator: 25
-  fuzziness:
-    numerator: 1
-    denominator: 5
-
+  fuzziness: 0.2
 - name: aws.billing.group_definition.type
   value: "DIMENSION"
 - name: aws.billing.group_by.INSTANCE_TYPE

--- a/assets/templates/aws.ec2_metrics/schema-b/configs.yml
+++ b/assets/templates/aws.ec2_metrics/schema-b/configs.yml
@@ -86,100 +86,72 @@
   range:
     min: 0
     max: 10
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: StatusCheckFailed_SystemAvg
   range:
     min: 0
     max: 10
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: StatusCheckFailedAvg
   range:
     min: 0
     max: 10
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: CPUUtilizationAvg
   range:
     min: 0
     max: 100
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: NetworkPacketsInSum
   range:
     min: 0
     max: 1500000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: NetworkPacketsOutSum
   range:
     min: 0
     max: 1500000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: CPUCreditBalanceAvg
   range:
     min: 0
     max: 5000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: CPUSurplusCreditBalanceAvg
   range:
     min: 0
     max: 5000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: CPUSurplusCreditsChargedAvg
   range:
     min: 0
     max: 5000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: CPUCreditUsageAvg
   range:
     min: 0
     max: 10
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: DiskReadBytesSum
   range:
     min: 0
     max: 1500000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: DiskReadOpsSum
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: DiskWriteBytesSum
   range:
     min: 0
     max: 1500000000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: DiskWriteOpsSum
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: EventDuration
   range:
     min: 1

--- a/assets/templates/aws.sqs/schema-b/configs.yml
+++ b/assets/templates/aws.sqs/schema-b/configs.yml
@@ -7,65 +7,47 @@
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: Deleted
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: NotVisible
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: Delayed
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: Received
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: Sent
   range:
     min: 0
     max: 1000
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: EmptyReceives
   range:
     min: 0
     max: 10
-  fuzziness:
-    numerator: 1
-    denominator: 10
+  fuzziness: 0.1
 - name: SentMessageSize
   range:
     min: 1024
     max: 262144
-  fuzziness:
-    numerator: 1
-    denominator: 2
+  fuzziness: 0.5
 - name: OldestMessageAge
   range:
     min: 1
     max: 7200
-  fuzziness:
-    numerator: 1
-    denominator: 20
+  fuzziness: 0.05
 - name: QueueName
   cardinality:
     numerator: 1

--- a/docs/field-configurations.md
+++ b/docs/field-configurations.md
@@ -10,7 +10,7 @@ The config file is a yaml file consisting of an array of config entry.
 
 For each config entry the following fields are available:
 - `name` *mandatory*: dotted path field, as in `fields.yml`
-- `fuzziness` *optional (`long` and `double` type only)*: delta from the previous generated value for the same field, expressed as a ratio between a `numerator` and a `denominator`
+- `fuzziness` *optional (`long` and `double` type only)*: maximum delta from the previous generated value for the same field, expressed as float where 1 = 100% 
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
 - `cardinality` *optional*: distribution of different values for the field, expressed as a ratio between a `numerator` and a `denominator`
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type; if not specified a random number of field names will be generated in the object filed type

--- a/docs/field-configurations.md
+++ b/docs/field-configurations.md
@@ -10,7 +10,7 @@ The config file is a yaml file consisting of an array of config entry.
 
 For each config entry the following fields are available:
 - `name` *mandatory*: dotted path field, as in `fields.yml`
-- `fuzziness` *optional (`long` and `double` type only)*: maximum delta from the previous generated value for the same field, expressed as float where 1 = 100% 
+- `fuzziness` *optional (`long` and `double` type only)*: when generating data you could want generated values to change in a known interval. Fuzziness allow to specify the maximum delta a generated value can have from the previous value (for the same field), as a delta percentage; value must be between 0.0 and 1.0, where 0 is 0% and 1 is 100%. When not specified there is no constraint on the generated values, boundaries will be defined by the underlying field type
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
 - `cardinality` *optional*: distribution of different values for the field, expressed as a ratio between a `numerator` and a `denominator`
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type; if not specified a random number of field names will be generated in the object filed type

--- a/pkg/genlib/config/config.go
+++ b/pkg/genlib/config/config.go
@@ -18,6 +18,7 @@ type Ratio struct {
 }
 
 type Range struct {
+  // NOTE: we want to distinguish when Min/Max are explicitly set to zero value or are not set at all. We use a pointer, such that when not set will be `nil`.
 	Min *float64 `config:"min"`
 	Max *float64 `config:"max"`
 }

--- a/pkg/genlib/config/config.go
+++ b/pkg/genlib/config/config.go
@@ -1,10 +1,16 @@
 package config
 
 import (
-	"github.com/elastic/go-ucfg/yaml"
+	"errors"
+
 	"io/ioutil"
+	"math"
 	"os"
+
+	"github.com/elastic/go-ucfg/yaml"
 )
+
+var rangeBoundNotSet = errors.New("range bound not set")
 
 type Ratio struct {
 	Numerator   int `config:"numerator"`
@@ -12,8 +18,8 @@ type Ratio struct {
 }
 
 type Range struct {
-	Min interface{} `config:"min"`
-	Max interface{} `config:"max"`
+	Min *float64 `config:"min"`
+	Max *float64 `config:"max"`
 }
 
 type Config struct {
@@ -22,12 +28,44 @@ type Config struct {
 
 type ConfigField struct {
 	Name        string   `config:"name"`
-	Fuzziness   Ratio    `config:"fuzziness"`
+	Fuzziness   float64  `config:"fuzziness"`
 	Range       Range    `config:"range"`
 	Cardinality Ratio    `config:"cardinality"`
 	Enum        []string `config:"enum"`
 	ObjectKeys  []string `config:"object_keys"`
 	Value       any      `config:"value"`
+}
+
+func (r Range) MinAsInt64() (int64, error) {
+	if r.Min == nil {
+		return 0, rangeBoundNotSet
+	}
+
+	return int64(*r.Min), nil
+}
+
+func (r Range) MaxAsInt64() (int64, error) {
+	if r.Max == nil {
+		return math.MaxInt64, rangeBoundNotSet
+	}
+
+	return int64(*r.Max), nil
+}
+
+func (r Range) MinAsFloat64() (float64, error) {
+	if r.Min == nil {
+		return 0, rangeBoundNotSet
+	}
+
+	return *r.Min, nil
+}
+
+func (r Range) MaxAsFloat64() (float64, error) {
+	if r.Max == nil {
+		return math.MaxFloat64, rangeBoundNotSet
+	}
+
+	return *r.Max, nil
 }
 
 func LoadConfig(configFile string) (Config, error) {

--- a/pkg/genlib/config/config_test.go
+++ b/pkg/genlib/config/config_test.go
@@ -1,0 +1,235 @@
+package config
+
+import (
+	"github.com/elastic/go-ucfg/yaml"
+	"math"
+	"testing"
+)
+
+func TestRange_MaxAsFloat64(t *testing.T) {
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  float64
+		hasError  bool
+	}{
+		{
+			scenario:  "max nil",
+			rangeYaml: "min: 10",
+			expected:  math.MaxFloat64,
+			hasError:  true,
+		},
+		{
+			scenario:  "float64",
+			rangeYaml: "max: 10.",
+			expected:  10,
+		},
+		{
+			scenario:  "uint64",
+			rangeYaml: "max: 10",
+			expected:  10,
+		},
+		{
+			scenario:  "int64",
+			rangeYaml: "max: -10",
+			expected:  -10,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.MaxAsFloat64()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}
+
+func TestRange_MaxAsInt64(t *testing.T) {
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  int64
+		hasError  bool
+	}{
+		{
+			scenario:  "max nil",
+			rangeYaml: "min: 10",
+			expected:  math.MaxInt64,
+			hasError:  true,
+		},
+		{
+			scenario:  "float64",
+			rangeYaml: "max: 10.",
+			expected:  10,
+		},
+		{
+			scenario:  "uint64",
+			rangeYaml: "max: 10",
+			expected:  10,
+		},
+		{
+			scenario:  "int64",
+			rangeYaml: "max: -10",
+			expected:  -10,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.MaxAsInt64()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}
+
+func TestRange_MinAsFloat64(t *testing.T) {
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  float64
+		hasError  bool
+	}{
+		{
+			scenario:  "min nil",
+			rangeYaml: "max: 10",
+			expected:  0,
+			hasError:  true,
+		},
+		{
+			scenario:  "float64",
+			rangeYaml: "min: 10.",
+			expected:  10,
+		},
+		{
+			scenario:  "uint64",
+			rangeYaml: "min: 10",
+			expected:  10,
+		},
+		{
+			scenario:  "int64",
+			rangeYaml: "min: -10",
+			expected:  -10,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.MinAsFloat64()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}
+
+func TestRange_MinAsInt64(t *testing.T) {
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  int64
+		hasError  bool
+	}{
+		{
+			scenario:  "min nil",
+			rangeYaml: "max: 10",
+			expected:  0,
+			hasError:  true,
+		},
+		{
+			scenario:  "float64",
+			rangeYaml: "min: 10.",
+			expected:  10,
+		},
+		{
+			scenario:  "uint64",
+			rangeYaml: "min: 10",
+			expected:  10,
+		},
+		{
+			scenario:  "int64",
+			rangeYaml: "min: -10",
+			expected:  -10,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.MinAsInt64()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}

--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -220,25 +220,11 @@ func bindByTypeWithReturn(cfg Config, field Field, fieldMap map[string]any) (err
 }
 
 func makeFloatFunc(fieldCfg ConfigField, field Field) func() float64 {
-	minValue := float64(0)
-	maxValue := float64(0)
-
-	switch fieldCfg.Range.Min.(type) {
-	case float64:
-		minValue = fieldCfg.Range.Min.(float64)
-	case uint64:
-		minValue = float64(fieldCfg.Range.Min.(uint64))
-	case int64:
-		minValue = float64(fieldCfg.Range.Min.(int64))
-	}
-
-	switch fieldCfg.Range.Max.(type) {
-	case float64:
-		maxValue = fieldCfg.Range.Max.(float64)
-	case uint64:
-		maxValue = float64(fieldCfg.Range.Max.(uint64))
-	case int64:
-		maxValue = float64(fieldCfg.Range.Max.(int64))
+	minValue, _ := fieldCfg.Range.MinAsFloat64()
+	maxValue, err := fieldCfg.Range.MaxAsFloat64()
+	// maxValue not set, let's set it to 0 for the sake of the switch above
+	if err != nil {
+		maxValue = 0
 	}
 
 	var dummyFunc func() float64
@@ -259,36 +245,26 @@ func makeFloatFunc(fieldCfg ConfigField, field Field) func() float64 {
 	return dummyFunc
 }
 
-func makeIntFunc(fieldCfg ConfigField, field Field) func() int {
-	minValue := 0
-	maxValue := 0
-
-	switch fieldCfg.Range.Min.(type) {
-	case uint64:
-		minValue = int(fieldCfg.Range.Min.(uint64))
-	case int64:
-		minValue = int(fieldCfg.Range.Min.(int64))
+func makeIntFunc(fieldCfg ConfigField, field Field) func() int64 {
+	minValue, _ := fieldCfg.Range.MinAsInt64()
+	maxValue, err := fieldCfg.Range.MaxAsInt64()
+	// maxValue not set, let's set it to 0 for the sake of the switch above
+	if err != nil {
+		maxValue = 0
 	}
 
-	switch fieldCfg.Range.Max.(type) {
-	case uint64:
-		maxValue = int(fieldCfg.Range.Max.(uint64))
-	case int64:
-		maxValue = int(fieldCfg.Range.Max.(int64))
-	}
-
-	var dummyFunc func() int
+	var dummyFunc func() int64
 
 	switch {
 	case maxValue > 0:
-		dummyFunc = func() int { return rand.Intn(maxValue-minValue) + minValue }
+		dummyFunc = func() int64 { return rand.Int63n(maxValue-minValue) + minValue }
 	case len(field.Example) == 0:
-		dummyFunc = func() int { return rand.Intn(10) }
+		dummyFunc = func() int64 { return rand.Int63n(10) }
 	default:
 		totDigit := len(field.Example)
-		max := int(math.Pow10(totDigit))
-		dummyFunc = func() int {
-			return rand.Intn(max)
+		max := int64(math.Pow10(totDigit))
+		dummyFunc = func() int64 {
+			return rand.Int63n(max)
 		}
 	}
 
@@ -539,17 +515,13 @@ func bindIP(field Field, fieldMap map[string]any) error {
 }
 
 func bindLong(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
-
 	dummyFunc := makeIntFunc(fieldCfg, field)
 
-	fuzzinessNumerator := float64(fieldCfg.Fuzziness.Numerator)
-	fuzzinessDenominator := float64(fieldCfg.Fuzziness.Denominator)
-
-	if fuzzinessNumerator <= 0 {
+	if fieldCfg.Fuzziness <= 0 {
 		var emitFNotReturn emitFNotReturn
 		emitFNotReturn = func(state *GenState, buf *bytes.Buffer) error {
 			v := make([]byte, 0, 32)
-			v = strconv.AppendInt(v, int64(dummyFunc()), 10)
+			v = strconv.AppendInt(v, dummyFunc(), 10)
 			buf.Write(v)
 			return nil
 		}
@@ -559,21 +531,22 @@ func bindLong(fieldCfg ConfigField, field Field, fieldMap map[string]any) error 
 		return nil
 	}
 
+	min, _ := fieldCfg.Range.MinAsFloat64()
+	max, _ := fieldCfg.Range.MaxAsFloat64()
+
 	var emitFNotReturn emitFNotReturn
 	emitFNotReturn = func(state *GenState, buf *bytes.Buffer) error {
 		dummyInt := dummyFunc()
 		if previousDummyInt, ok := state.prevCache[field.Name].(int); ok {
-			adjustedRatio := rand.Float64() * (fuzzinessNumerator / fuzzinessDenominator)
-			if rand.Int()%2 == 0 {
-				adjustedRatio += 1.
-			} else {
-				adjustedRatio = 1. - adjustedRatio
-			}
-			dummyInt = int(math.Ceil(float64(previousDummyInt) * adjustedRatio))
+			lowerBound := float64(previousDummyInt) * (1 - fieldCfg.Fuzziness)
+			higherBound := float64(previousDummyInt) * (1 + fieldCfg.Fuzziness)
+			lowerBound = math.Max(lowerBound, min)
+			higherBound = math.Min(higherBound, max)
+			dummyInt = rand.Int63n(int64(math.Ceil(higherBound-lowerBound))) + int64(lowerBound)
 		}
 		state.prevCache[field.Name] = dummyInt
 		v := make([]byte, 0, 32)
-		v = strconv.AppendInt(v, int64(dummyInt), 10)
+		v = strconv.AppendInt(v, dummyInt, 10)
 		buf.Write(v)
 		return nil
 	}
@@ -583,13 +556,9 @@ func bindLong(fieldCfg ConfigField, field Field, fieldMap map[string]any) error 
 }
 
 func bindDouble(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
-
 	dummyFunc := makeFloatFunc(fieldCfg, field)
 
-	fuzzinessNumerator := float64(fieldCfg.Fuzziness.Numerator)
-	fuzzinessDenominator := float64(fieldCfg.Fuzziness.Denominator)
-
-	if fuzzinessNumerator <= 0 {
+	if fieldCfg.Fuzziness <= 0 {
 		var emitFNotReturn emitFNotReturn
 		emitFNotReturn = func(state *GenState, buf *bytes.Buffer) error {
 			dummyFloat := dummyFunc()
@@ -601,17 +570,18 @@ func bindDouble(fieldCfg ConfigField, field Field, fieldMap map[string]any) erro
 		return nil
 	}
 
+	min, _ := fieldCfg.Range.MinAsFloat64()
+	max, _ := fieldCfg.Range.MaxAsFloat64()
+
 	var emitFNotReturn emitFNotReturn
 	emitFNotReturn = func(state *GenState, buf *bytes.Buffer) error {
 		dummyFloat := dummyFunc()
 		if previousDummyFloat, ok := state.prevCache[field.Name].(float64); ok {
-			adjustedRatio := rand.Float64() * (fuzzinessNumerator / fuzzinessDenominator)
-			if rand.Int()%2 == 0 {
-				adjustedRatio += 1.
-			} else {
-				adjustedRatio = 1. - adjustedRatio
-			}
-			dummyFloat = previousDummyFloat * adjustedRatio
+			lowerBound := previousDummyFloat * (1 - fieldCfg.Fuzziness)
+			higherBound := previousDummyFloat * (1 + fieldCfg.Fuzziness)
+			lowerBound = math.Max(lowerBound, min)
+			higherBound = math.Min(higherBound, max)
+			dummyFloat = lowerBound + rand.Float64()*(higherBound-lowerBound)
 		}
 		state.prevCache[field.Name] = dummyFloat
 		_, err := fmt.Fprintf(buf, "%f", dummyFloat)
@@ -857,13 +827,9 @@ func bindIPWithReturn(field Field, fieldMap map[string]any) error {
 }
 
 func bindLongWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
-
 	dummyFunc := makeIntFunc(fieldCfg, field)
 
-	fuzzinessNumerator := float64(fieldCfg.Fuzziness.Numerator)
-	fuzzinessDenominator := float64(fieldCfg.Fuzziness.Denominator)
-
-	if fuzzinessNumerator <= 0 {
+	if fieldCfg.Fuzziness <= 0 {
 		var emitF EmitF
 		emitF = func(state *GenState) any {
 			return dummyFunc()
@@ -873,17 +839,18 @@ func bindLongWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]a
 		return nil
 	}
 
+	min, _ := fieldCfg.Range.MinAsFloat64()
+	max, _ := fieldCfg.Range.MaxAsFloat64()
+
 	var emitF EmitF
 	emitF = func(state *GenState) any {
 		dummyInt := dummyFunc()
 		if previousDummyInt, ok := state.prevCache[field.Name].(int); ok {
-			adjustedRatio := rand.Float64() * (fuzzinessNumerator / fuzzinessDenominator)
-			if rand.Int()%2 == 0 {
-				adjustedRatio += 1.
-			} else {
-				adjustedRatio = 1. - adjustedRatio
-			}
-			dummyInt = int(math.Ceil(float64(previousDummyInt) * adjustedRatio))
+			lowerBound := float64(previousDummyInt) * (1 - fieldCfg.Fuzziness)
+			higherBound := float64(previousDummyInt) * (1 + fieldCfg.Fuzziness)
+			lowerBound = math.Max(lowerBound, min)
+			higherBound = math.Min(higherBound, max)
+			dummyInt = rand.Int63n(int64(math.Ceil(higherBound-lowerBound))) + int64(lowerBound)
 		}
 		state.prevCache[field.Name] = dummyInt
 		return dummyInt
@@ -894,13 +861,9 @@ func bindLongWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]a
 }
 
 func bindDoubleWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
-
 	dummyFunc := makeFloatFunc(fieldCfg, field)
 
-	fuzzinessNumerator := float64(fieldCfg.Fuzziness.Numerator)
-	fuzzinessDenominator := float64(fieldCfg.Fuzziness.Denominator)
-
-	if fuzzinessNumerator <= 0 {
+	if fieldCfg.Fuzziness <= 0 {
 		var emitF EmitF
 		emitF = func(state *GenState) any {
 			return dummyFunc()
@@ -911,17 +874,18 @@ func bindDoubleWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string
 		return nil
 	}
 
+	min, _ := fieldCfg.Range.MinAsFloat64()
+	max, _ := fieldCfg.Range.MaxAsFloat64()
+
 	var emitF EmitF
 	emitF = func(state *GenState) any {
 		dummyFloat := dummyFunc()
 		if previousDummyFloat, ok := state.prevCache[field.Name].(float64); ok {
-			adjustedRatio := rand.Float64() * (fuzzinessNumerator / fuzzinessDenominator)
-			if rand.Int()%2 == 0 {
-				adjustedRatio += 1.
-			} else {
-				adjustedRatio = 1. - adjustedRatio
-			}
-			dummyFloat = previousDummyFloat * adjustedRatio
+			lowerBound := previousDummyFloat * (1 - fieldCfg.Fuzziness)
+			higherBound := previousDummyFloat * (1 + fieldCfg.Fuzziness)
+			lowerBound = math.Max(lowerBound, min)
+			higherBound = math.Min(higherBound, max)
+			dummyFloat = lowerBound + rand.Float64()*(higherBound-lowerBound)
 		}
 		state.prevCache[field.Name] = dummyFloat
 		return dummyFloat


### PR DESCRIPTION
`fuzziness` field is now a single float value that expressed as `1 == 100%` variation delta from the previous value
values generated by applying `fuzziness` now respects defined `range` constraint, if present

closes #76 