### PR TITLE
Remove timeDuration

### DIFF
--- a/assets/templates/aws.vpcflow/schema-a/gotext.tpl
+++ b/assets/templates/aws.vpcflow/schema-a/gotext.tpl
@@ -1,4 +1,4 @@
 {{- $startOffset := generate "StartOffset" }}
 {{- $end := generate "End" }}
-{{- $start := mul -1 $startOffset | int64 | duration | $end.Add }}
+{{- $start := $end | dateModify (mul -1 $startOffset | int64 | duration) }}
 {{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{mul $packets 15 }} {{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}

--- a/assets/templates/aws.vpcflow/schema-a/gotext.tpl
+++ b/assets/templates/aws.vpcflow/schema-a/gotext.tpl
@@ -1,6 +1,4 @@
 {{- $startOffset := generate "StartOffset" }}
-{{- $startOffsetInSecond := mul -1 1000000000 $startOffset }}
-{{- $startOffsetDuration := $startOffsetInSecond | int64 | duration}}
 {{- $end := generate "End" }}
-{{- $start := $end.Add $startOffsetDuration}}
+{{- $start := mul -1 $startOffset | int64 | duration | $end.Add }}
 {{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{mul $packets 15 }} {{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}

--- a/assets/templates/aws.vpcflow/schema-a/gotext.tpl
+++ b/assets/templates/aws.vpcflow/schema-a/gotext.tpl
@@ -1,1 +1,6 @@
-{{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{mul $packets 15 }} {{$startOffset := generate "StartOffset" }}{{$startOffsetInSecond := mul -1 1000000000 $startOffset }}{{$startOffsetDuration := timeDuration $startOffsetInSecond}}{{$end := generate "End" }}{{$start := $end.Add $startOffsetDuration}}{{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}
+{{- $startOffset := generate "StartOffset" }}
+{{- $startOffsetInSecond := mul -1 1000000000 $startOffset }}
+{{- $startOffsetDuration := $startOffsetInSecond | int64 | duration}}
+{{- $end := generate "End" }}
+{{- $start := $end.Add $startOffsetDuration}}
+{{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{mul $packets 15 }} {{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}

--- a/docs/writing-templates.md
+++ b/docs/writing-templates.md
@@ -78,9 +78,3 @@ This is equivalent to the following when using the `placeholder` template type:
 
 #### sprig functions
 The template loads the functions provided by sprig (https://masterminds.github.io/sprig/) with the exclusion of the functions are not guaranteed to evaluate to the same result for given input (https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/functions.go#L68-L95)
-
-#### "timeDuration" function
-The template provides a function named "timeDuration" that accept an int64 and return equivalent `time.Duration`, for example the following will render `5s`:
-```text
-{{$timeDuration := timeDuration 5000000000}}{{$timeDuration}} 
-```

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/rand"
 	"text/template"
-	"time"
 
 	"github.com/Masterminds/sprig/v3"
 )
@@ -126,10 +125,6 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totSize
 	errChan := make(chan error)
 
 	templateFns := sprig.TxtFuncMap()
-
-	templateFns["timeDuration"] = func(duration int64) time.Duration {
-		return time.Duration(duration)
-	}
 
 	templateFns["awsAZFromRegion"] = func(region string) string {
 		azs, ok := awsAZs[region]


### PR DESCRIPTION
Following up on discussion in #62 this PR removes `timeDuration` helper function.

The same functionality is provided by `sprig`. This:
```
{{$startOffsetDuration := timeDuration $startOffsetInSecond}}
```

becomes 
```
{{$startOffsetDuration := $startOffsetInSecond | int64 | duration}}
```