### PR TITLE
ci: bypass the mandatory check

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,20 @@
+---
+# This workflow sets the ci / test status check to success in case it's a docs only PR and ci.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: ci # The name must be the same as in ci.yml
+
+on:
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on ci.yml.
+      - '**'
+      - '!**/*.md'
+      - '!**/*.asciidoc'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
 when running only for docs

Based on https://github.com/elastic/apm-agent-python/pull/1753

Notifies https://github.com/elastic/elastic-integration-corpus-generator-tool/pull/82