### PR TITLE
set proper datastream type in _index bulk action for generate command

### DIFF
--- a/internal/corpus/generator.go
+++ b/internal/corpus/generator.go
@@ -179,12 +179,12 @@ func (gc GeneratorCorpus) Generate(packageRegistryBaseURL, integrationPackage, d
 	}
 
 	ctx := context.Background()
-	flds, err := fields.LoadFields(ctx, packageRegistryBaseURL, integrationPackage, dataStream, packageVersion)
+	flds, dataStreamType, err := fields.LoadFields(ctx, packageRegistryBaseURL, integrationPackage, dataStream, packageVersion)
 	if err != nil {
 		return "", err
 	}
 
-	createPayload := []byte(`{ "create" : { "_index": "metrics-` + integrationPackage + `.` + dataStream + `-default" } }` + "\n")
+	createPayload := []byte(`{ "create" : { "_index": "` + dataStreamType + `-` + integrationPackage + `.` + dataStream + `-default" } }` + "\n")
 
 	err = gc.eventsPayloadFromFields(nil, flds, totSizeInBytes, createPayload, f)
 	if err != nil {

--- a/pkg/genlib/fields/cache.go
+++ b/pkg/genlib/fields/cache.go
@@ -85,7 +85,7 @@ func (f *Cache) LoadFields(ctx context.Context, integration, stream, version str
 
 	if !ok {
 
-		if flds, err = LoadFields(ctx, f.baseUrl, integration, stream, version); err != nil {
+		if flds, _, err = LoadFields(ctx, f.baseUrl, integration, stream, version); err != nil {
 			return nil, err
 		} else {
 			f.mut.Lock()

--- a/pkg/genlib/generator_test.go
+++ b/pkg/genlib/generator_test.go
@@ -11,7 +11,7 @@ import (
 
 func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 	ctx := context.Background()
-	flds, err := fields.LoadFields(ctx, fields.ProductionBaseURL, "endpoint", "process", "8.2.0")
+	flds, _, err := fields.LoadFields(ctx, fields.ProductionBaseURL, "endpoint", "process", "8.2.0")
 
 	template, objectKeysField := generateCustomTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
@@ -39,7 +39,7 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 
 func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 	ctx := context.Background()
-	flds, err := fields.LoadFields(ctx, fields.ProductionBaseURL, "endpoint", "process", "8.2.0")
+	flds, _, err := fields.LoadFields(ctx, fields.ProductionBaseURL, "endpoint", "process", "8.2.0")
 
 	template, objectKeysField := generateTextTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)


### PR DESCRIPTION
with `generate` command, the `_index` in the bulk request output was hardcoded to `metrics`: ie
```
{ "create" : { "_index": "metrics-azure.springcloudlogs-default" } }
```

not the type of the datastream is properly set according to the type in the manifest for the integration package