### PR TITLE
Tot events instead of tot size

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -82,6 +82,6 @@ func GenerateCmd() *cobra.Command {
 
 	generateCmd.Flags().StringVarP(&packageRegistryBaseURL, "package-registry-base-url", "r", "https://epr.elastic.co/", "base url of the package registry with schema")
 	generateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
-	generateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
+	generateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	return generateCmd
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -34,10 +34,6 @@ func GenerateCmd() *cobra.Command {
 				errs = append(errs, errors.New("you must provide a not empty --package-registry-base-url flag value"))
 			}
 
-			if totSize == "" {
-				errs = append(errs, errors.New("you must provide a not empty --tot-size flag value"))
-			}
-
 			integrationPackage = args[0]
 			if integrationPackage == "" {
 				errs = append(errs, errors.New("you must provide a not empty integration argument"))
@@ -73,7 +69,7 @@ func GenerateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totSize)
+			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totEvents)
 			if err != nil {
 				return err
 			}
@@ -86,6 +82,6 @@ func GenerateCmd() *cobra.Command {
 
 	generateCmd.Flags().StringVarP(&packageRegistryBaseURL, "package-registry-base-url", "r", "https://epr.elastic.co/", "base url of the package registry with schema")
 	generateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
-	generateCmd.Flags().StringVarP(&totSize, "tot-size", "t", "", "total size of the corpus to generate")
+	generateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
 	return generateCmd
 }

--- a/cmd/generate_common.go
+++ b/cmd/generate_common.go
@@ -2,4 +2,4 @@ package cmd
 
 var packageRegistryBaseURL string
 var configFile string
-var totSize string
+var totEvents uint64

--- a/cmd/generate_with_template.go
+++ b/cmd/generate_with_template.go
@@ -31,10 +31,6 @@ func GenerateWithTemplateCmd() *cobra.Command {
 				return errors.New("you must pass the template path and the fields definition path")
 			}
 
-			if totSize == "" {
-				errs = append(errs, errors.New("you must provide a not empty --tot-size flag value"))
-			}
-
 			templatePath = args[0]
 			if templatePath == "" {
 				errs = append(errs, errors.New("you must provide a not empty template path argument"))
@@ -65,7 +61,7 @@ func GenerateWithTemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totSize)
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents)
 			if err != nil {
 				return err
 			}
@@ -78,6 +74,6 @@ func GenerateWithTemplateCmd() *cobra.Command {
 
 	generateWithTemplateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	generateWithTemplateCmd.Flags().StringVarP(&templateType, "template-type", "y", "placeholder", "either 'placeholder' or 'gotext'")
-	generateWithTemplateCmd.Flags().StringVarP(&totSize, "tot-size", "t", "", "total size of the corpus to generate")
+	generateWithTemplateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
 	return generateWithTemplateCmd
 }

--- a/cmd/generate_with_template.go
+++ b/cmd/generate_with_template.go
@@ -74,6 +74,6 @@ func GenerateWithTemplateCmd() *cobra.Command {
 
 	generateWithTemplateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	generateWithTemplateCmd.Flags().StringVarP(&templateType, "template-type", "y", "placeholder", "either 'placeholder' or 'gotext'")
-	generateWithTemplateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
+	generateWithTemplateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	return generateWithTemplateCmd
 }

--- a/cmd/local-template.go
+++ b/cmd/local-template.go
@@ -93,7 +93,7 @@ func TemplateCmd() *cobra.Command {
 
 	command.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	command.Flags().StringVarP(&templateType, "engine", "e", "gotext", "either 'placeholder' or 'gotext'")
-	command.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
+	command.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	command.Flags().StringVarP(&flag_schema, "schema", "", "b", "schema to generate data for; valid values: a, b")
 	return command
 }

--- a/cmd/local-template.go
+++ b/cmd/local-template.go
@@ -80,7 +80,7 @@ func TemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totSize)
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ func TemplateCmd() *cobra.Command {
 
 	command.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	command.Flags().StringVarP(&templateType, "engine", "e", "gotext", "either 'placeholder' or 'gotext'")
-	command.Flags().StringVarP(&totSize, "size", "s", "1", "total size of the corpus to generate")
+	command.Flags().Uint64VarP(&totEvents, "tot-events", "t", 0, "total events of the corpus to generate")
 	command.Flags().StringVarP(&flag_schema, "schema", "", "b", "schema to generate data for; valid values: a, b")
 	return command
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,9 +6,9 @@ To do this, use the `generate` command. This command targets a specific dataset 
 
 You can pass a local Fields generation configuration file.
 
-`go run main.go generate <package> <dataset> <version> --tot-size <quantity>`
+`go run main.go generate <package> <dataset> <version> --tot-events <quantity>`
 
-`package`, `dataset` and `version` are mandatory. `--tot-size` is mandatory.
+`package`, `dataset` and `version` are mandatory. `--tot-events` is not mandatory and in case it is not provided an infinite number of events will be generated.
 
 **Example**:
 
@@ -26,14 +26,14 @@ A body of templates, fields definition and fields generation configuration are a
 
 You can pass a local Fields generation configuration file.
 
-`go run main.go generate-with-template <template-path> <fields-definition-path> --tot-size <quantity>`
+`go run main.go generate-with-template <template-path> <fields-definition-path> --tot-events <quantity>`
 
-`template-path` and `fields-definition-path` are mandatory. `--tot-size` is mandatory.
+`template-path` and `fields-definition-path` are mandatory `--tot-events` is not mandatory and in case it is not provided an infinite number of events will be generated.
 
 **Example**:
 
 ```shell
-$ go run main.go generate-with-template ./assets/templates/aws.vpcflow/vpcflow.gotext.log ./assets/templates/aws.vpcflow/vpcflow.fields.yml -t 20KB --config-file ./assets/templates/aws.vpcflow/vpcflow.conf.yml -y gotext -t 1000
-File generated: /Users/andreaspacca/Library/Application Support/elastic-integration-corpus-generator-tool/corpora/1672731603-vpcflow.gotext.log
+$ go run main.go generate-with-template ./assets/templates/aws.vpcflow/schema-a/gotext.tpl ./assets/templates/aws.vpcflow/schema-a/fields.yml -t 1000 --config-file ./assets/templates/aws.vpcflow/schema-a/configs.yml -y gotext
+File generated: /path/to/corpora/1684304483-gotext.tpl
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ You can pass a local Fields generation configuration file.
 
 `go run main.go generate <package> <dataset> <version> --tot-events <quantity>`
 
-`package`, `dataset` and `version` are mandatory. `--tot-events` is not mandatory and in case it is not provided an infinite number of events will be generated.
+`package`, `dataset` and `version` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`. 
 
 **Example**:
 
@@ -28,7 +28,7 @@ You can pass a local Fields generation configuration file.
 
 `go run main.go generate-with-template <template-path> <fields-definition-path> --tot-events <quantity>`
 
-`template-path` and `fields-definition-path` are mandatory `--tot-events` is not mandatory and in case it is not provided an infinite number of events will be generated.
+`template-path` and `fields-definition-path` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`.
 
 **Example**:
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/OpenPeeDeeP/xdg v1.0.0
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/go-ucfg v0.8.6
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/spf13/afero v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
-github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elastic/go-ucfg v0.8.6 h1:stUeyh2goTgGX+/wb9gzKvTv0YB0231LTpKUgCKj4U0=
 github.com/elastic/go-ucfg v0.8.6/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -162,9 +162,9 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int) ([
 	return templateBuffer.Bytes(), objectKeysField
 }
 
-func NewGenerator(cfg Config, flds Fields, totSize uint64) (Generator, error) {
+func NewGenerator(cfg Config, flds Fields, totEvents uint64) (Generator, error) {
 	template, objectKeysField := generateCustomTemplateFromField(cfg, flds)
 	flds = append(flds, objectKeysField...)
 
-	return NewGeneratorWithCustomTemplate(template, cfg, flds, totSize)
+	return NewGeneratorWithCustomTemplate(template, cfg, flds, totEvents)
 }

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -548,8 +548,8 @@ func testSingleTWithCustomTemplate[T any](t *testing.T, fld Field, yaml []byte, 
 	return v
 }
 
-func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totSize uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totSize)
+func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -81,7 +81,7 @@ func test_CardinalityTWithTextTemplate[T any](t *testing.T, ty string) {
 		}
 
 		nSpins := 16384
-		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(len(template)*nSpins*1024))
+		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(nSpins))
 
 		vmapAlpha := make(map[any]int)
 		vmapBeta := make(map[any]int)
@@ -388,8 +388,8 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 	return v
 }
 
-func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totSize uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totSize)
+func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
+	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
talking with different people consuming the package we found out that is preferred to indicate to total number of events to generate rather than the total size.
there are a couple of reasons mostly:
1. current users have knowledge of how many events they want to generate, and find themselves to figure out to translate this information in terms of size instead
2. internally we try to figure out back the number of events from the size: this is required to provide evenly distributed data in features we will want to add (like providing a field configuration definition of a `period` to generate data for in case of a `date` field): the way we do this is to rendere once the target template and divide its size by the total size requested. this indeed is a limit and it requires a better strategy (like rendering the template multiple times: most probably up to the highest cardinality) in order to achieve a meaningful approximation (currently for `aws.ec2_metrics`, for example, the tool can end up generating double the size requested because of a the non meaningful approximation).

considering the two points above we decided to just drop indicating a total size to generate in favour of a total number of events. beware that it is now possible, omitting the `--tot-events` flag or setting it to `0` to generate an infinite number of events