### PR TITLE
Time period

### DIFF
--- a/docs/fields-configuration.md
+++ b/docs/fields-configuration.md
@@ -13,6 +13,7 @@ For each config entry the following fields are available:
 - `fuzziness` *optional (`long` and `double` type only)*: when generating data you could want generated values to change in a known interval. Fuzziness allow to specify the maximum delta a generated value can have from the previous value (for the same field), as a delta percentage; value must be between 0.0 and 1.0, where 0 is 0% and 1 is 100%. When not specified there is no constraint on the generated values, boundaries will be defined by the underlying field type
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
 - `cardinality` *optional*: number of different values for the field; note that this value may not be respected if not enough events are generated. Es `cardinality: 1000` with `100` generated events would produce `100` different values, not `1000`.
+- `period` *optional (`date` type only)*: values will be evenly generated between `time.Now()` and `time.Now().Add(period)`, where period is expressed as `time.Duration`
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type; if not specified a random number of field names will be generated in the object filed type
 - `value` *optional*: hardcoded value to set for the field (any `cardinality` will be ignored)
 - `enum` *optional (`keyword` type only)*: list of strings to randomly chose from a value to set for the field (any `cardinality` will be applied limited to the size of the `enum` values)

--- a/docs/fields-configuration.md
+++ b/docs/fields-configuration.md
@@ -23,34 +23,75 @@ If you have an `object` type field that you defined one or multiple `object_keys
 ## Example configuration
 
 ```yaml
-- name: aws.dynamodb.metrics.AccountMaxReads.max
-  fuzziness: 0.1
-  range:
-    min: 0
-    max: 100
-- name: aws.dynamodb.metrics.AccountMaxTableLevelReads.max
-  fuzziness: 0.05
-  range:
-    min: 0
-    max: 50
-  cardinality: 20
-- name: aws.dynamodb.metrics.AccountProvisionedReadCapacityUtilization.avg
-  fuzziness: 0.1
-- name: aws.cloudwatch.namespace
-  cardinality: 1000
-- name: aws.dimensions.*
-  object_keys:
-    - TableName
-    - Operation
-- name: data_stream.type
-  value: metrics
-- name: data_stream.dataset
-  value: aws.dynamodb
-- name: data_stream.namespace
-  value: default
-- name: aws.dimensions.TableName
-  enum: ["table1", "table2"]
-- name: aws.dimensions.Operation
-  cardinality: 2
+fields:
+  - name: timestamp
+    period: "1h"
+  - name: aws.dynamodb.metrics.AccountMaxReads.max
+    fuzziness: 0.1
+    range:
+      min: 0
+      max: 100
+  - name: aws.dynamodb.metrics.AccountMaxTableLevelReads.max
+    fuzziness: 0.05
+    range:
+      min: 0
+      max: 50
+    cardinality: 20
+  - name: aws.dynamodb.metrics.AccountProvisionedReadCapacityUtilization.avg
+    fuzziness: 0.1
+  - name: aws.cloudwatch.namespace
+    cardinality: 1000
+  - name: aws.dimensions.*
+    object_keys:
+      - TableName
+      - Operation
+  - name: data_stream.type
+    value: metrics
+  - name: data_stream.dataset
+    value: aws.dynamodb
+  - name: data_stream.namespace
+    value: default
+  - name: aws.dimensions.TableName
+    enum: ["table1", "table2"]
+  - name: aws.dimensions.Operation
+    cardinality: 2
 ```
 
+Related [fields definition](./writing-templates.md#fieldsyml---fields-definition)
+```yaml
+- name: timestamp
+  type: date
+- name: data_stream.type
+  type: constant_keyword
+- name: data_stream.dataset
+  type: constant_keyword
+- name: data_stream.namespace
+  type: constant_keyword
+- name: aws
+  type: group
+  fields:
+    - name: dimensions
+      type: group
+      fields:
+        - name: Operation
+          type: keyword
+        - name: TableName
+          type: keyword
+    - name: dynamodb
+      type: group
+      fields:
+        - name: metrics
+          type: group
+          fields:
+            - name: AccountProvisionedReadCapacityUtilization.avg
+              type: double
+            - name: AccountMaxReads.max
+              type: long
+            - name: AccountMaxTableLevelReads.max
+              type: long
+    - name: cloudwatch
+      type: group
+      fields:
+        - name: namespace
+          type: keyword
+```

--- a/pkg/genlib/config/config.go
+++ b/pkg/genlib/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"time"
 
 	"math"
 	"os"
@@ -23,13 +24,14 @@ type Config struct {
 }
 
 type ConfigField struct {
-	Name        string   `config:"name"`
-	Fuzziness   float64  `config:"fuzziness"`
-	Range       Range    `config:"range"`
-	Cardinality int      `config:"cardinality"`
-	Enum        []string `config:"enum"`
-	ObjectKeys  []string `config:"object_keys"`
-	Value       any      `config:"value"`
+	Name        string        `config:"name"`
+	Fuzziness   float64       `config:"fuzziness"`
+	Range       Range         `config:"range"`
+	Cardinality int           `config:"cardinality"`
+	Period      time.Duration `config:"period"`
+	Enum        []string      `config:"enum"`
+	ObjectKeys  []string      `config:"object_keys"`
+	Value       any           `config:"value"`
 }
 
 func (r Range) MinAsInt64() (int64, error) {

--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -22,6 +22,12 @@ import (
 	"time"
 )
 
+var timeNow time.Time
+
+func init() {
+	timeNow = time.Now()
+}
+
 type (
 	Fields      = fields.Fields
 	Field       = fields.Field
@@ -71,6 +77,8 @@ type Generator interface {
 type GenState struct {
 	// event counter
 	counter uint64
+	// total events
+	totEvents uint64
 	// previous value cache; necessary for fuzziness, cardinality, etc.
 	prevCache map[string]any
 	// previous value cache for dup check; necessary for cardinality
@@ -165,7 +173,7 @@ func bindByType(cfg Config, field Field, fieldMap map[string]any) (err error) {
 
 	switch field.Type {
 	case FieldTypeDate:
-		err = bindNearTime(field, fieldMap)
+		err = bindNearTime(fieldCfg, field, fieldMap)
 	case FieldTypeIP:
 		err = bindIP(field, fieldMap)
 	case FieldTypeDouble, FieldTypeFloat, FieldTypeHalfFloat, FieldTypeScaledFloat:
@@ -195,7 +203,7 @@ func bindByTypeWithReturn(cfg Config, field Field, fieldMap map[string]any) (err
 
 	switch field.Type {
 	case FieldTypeDate:
-		err = bindNearTimeWithReturn(field, fieldMap)
+		err = bindNearTimeWithReturn(fieldCfg, field, fieldMap)
 	case FieldTypeIP:
 		err = bindIPWithReturn(field, fieldMap)
 	case FieldTypeDouble, FieldTypeFloat, FieldTypeHalfFloat, FieldTypeScaledFloat:
@@ -492,11 +500,17 @@ func bindWordN(field Field, n int, fieldMap map[string]any) error {
 	return nil
 }
 
-func bindNearTime(field Field, fieldMap map[string]any) error {
+func bindNearTime(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
 	var emitFNotReturn emitFNotReturn
 	emitFNotReturn = func(state *GenState, buf *bytes.Buffer) error {
-		offset := time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
-		newTime := time.Now().Add(offset)
+		var offset time.Duration
+		if fieldCfg.Period > 0 && state.totEvents > 0 {
+			offset = time.Duration((fieldCfg.Period.Nanoseconds() / int64(state.totEvents)) * int64(state.counter))
+		} else {
+			offset = time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
+		}
+
+		newTime := timeNow.Add(offset)
 
 		buf.WriteString(newTime.Format(FieldTypeTimeLayout))
 		return nil
@@ -826,11 +840,17 @@ func bindWordNWithReturn(field Field, n int, fieldMap map[string]any) error {
 	return nil
 }
 
-func bindNearTimeWithReturn(field Field, fieldMap map[string]any) error {
+func bindNearTimeWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]any) error {
 	var emitF EmitF
 	emitF = func(state *GenState) any {
-		offset := time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
-		newTime := time.Now().Add(offset)
+		var offset time.Duration
+		if fieldCfg.Period > 0 {
+			offset = time.Duration((fieldCfg.Period.Nanoseconds() / int64(state.totEvents)) * int64(state.counter))
+		} else {
+			offset = time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
+		}
+
+		newTime := timeNow.Add(offset)
 
 		return newTime
 	}

--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -111,6 +111,8 @@ func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, 
 		})
 	}
 
+	state.totEvents = totEvents
+
 	return &GeneratorWithCustomTemplate{emitters: emitters, trailingTemplate: trailingTemplate, totEvents: totEvents, state: state}, nil
 }
 

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -507,9 +507,9 @@ func Test_FieldDateAndPeriodWithCustomTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNow.Add(time.Second * time.Duration(i))
+			expectedTime := timeNow.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
 
-			diff := expectedTime.Sub(ts)
+			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -465,6 +465,58 @@ func Test_FieldDateWithCustomTemplate(t *testing.T) {
 	}
 }
 
+func Test_FieldDateAndPeriodWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte("fields:\n  - name: alpha\n    period: 10s")
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, state := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	nSpins := 10
+	for i := 0; i < nSpins; i++ {
+		if err := g.Emit(state, &buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +1s for every iteration
+			expectedTime := timeNow.Add(time.Second * time.Duration(i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
 func Test_FieldIPWithCustomTemplate(t *testing.T) {
 	fld := Field{
 		Name: "alpha",

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -93,6 +93,8 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEven
 		return nil, err
 	}
 
+	state.totEvents = totEvents
+
 	return &GeneratorWithTextTemplate{tpl: parsedTpl, totEvents: totEvents, state: state, errChan: errChan}, nil
 }
 

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -305,6 +305,58 @@ func Test_FieldDateWithTextTemplate(t *testing.T) {
 	}
 }
 
+func Test_FieldDateAndPeriodWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte("fields:\n  - name: alpha\n    period: 10s")
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	nSpins := 10
+	for i := 0; i < nSpins; i++ {
+		if err := g.Emit(state, &buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +1s for every iteration
+			expectedTime := timeNow.Add(time.Second * time.Duration(i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
 func Test_FieldIPWithTextTemplate(t *testing.T) {
 	fld := Field{
 		Name: "alpha",

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -347,9 +347,9 @@ func Test_FieldDateAndPeriodWithTextTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNow.Add(time.Second * time.Duration(i))
+			expectedTime := timeNow.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
 
-			diff := expectedTime.Sub(ts)
+			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}


### PR DESCRIPTION
Date time field can now be configured to be evenly generated across a defined period as between `time.Now()` and `time.Now().Add(period)`, where period is `time.Duration`

This way users can simulate events across N hours/days (/or whatever)