### PR TITLE
Add now flag

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,6 +18,7 @@ import (
 var integrationPackage string
 var dataStream string
 var packageVersion string
+var timeNowAsString string
 
 func GenerateCmd() *cobra.Command {
 	generateCmd := &cobra.Command{
@@ -69,7 +70,12 @@ func GenerateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totEvents)
+			timeNow, err := getTimeNowFromFlag(timeNowAsString)
+			if err != nil {
+				return err
+			}
+
+			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totEvents, timeNow)
 			if err != nil {
 				return err
 			}
@@ -83,5 +89,6 @@ func GenerateCmd() *cobra.Command {
 	generateCmd.Flags().StringVarP(&packageRegistryBaseURL, "package-registry-base-url", "r", "https://epr.elastic.co/", "base url of the package registry with schema")
 	generateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	generateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
+	generateCmd.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
 	return generateCmd
 }

--- a/cmd/generate_common.go
+++ b/cmd/generate_common.go
@@ -1,5 +1,24 @@
 package cmd
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib"
+)
+
 var packageRegistryBaseURL string
 var configFile string
 var totEvents uint64
+
+func getTimeNowFromFlag(timeNowAsString string) (time.Time, error) {
+	if len(timeNowAsString) > 0 {
+		if timeNow, err := time.Parse(genlib.FieldTypeTimeLayout, timeNowAsString); err != nil {
+			return timeNow, fmt.Errorf("wrong --now flag: %s (%w)", timeNowAsString, err)
+		} else {
+			return timeNow, nil
+		}
+	}
+
+	return time.Now(), nil
+}

--- a/cmd/generate_with_template.go
+++ b/cmd/generate_with_template.go
@@ -61,7 +61,12 @@ func GenerateWithTemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents)
+			timeNow, err := getTimeNowFromFlag(timeNowAsString)
+			if err != nil {
+				return err
+			}
+
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow)
 			if err != nil {
 				return err
 			}
@@ -75,5 +80,6 @@ func GenerateWithTemplateCmd() *cobra.Command {
 	generateWithTemplateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	generateWithTemplateCmd.Flags().StringVarP(&templateType, "template-type", "y", "placeholder", "either 'placeholder' or 'gotext'")
 	generateWithTemplateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
+	generateWithTemplateCmd.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
 	return generateWithTemplateCmd
 }

--- a/cmd/local-template.go
+++ b/cmd/local-template.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-var flag_schema string
+var flagSchema string
 
 func TemplateCmd() *cobra.Command {
 	command := &cobra.Command{
@@ -50,7 +50,7 @@ func TemplateCmd() *cobra.Command {
 
 			var errs []error
 			datasetFolder := fmt.Sprintf("%s.%s", args[0], args[1])
-			schema := fmt.Sprintf("schema-%s", flag_schema)
+			schema := fmt.Sprintf("schema-%s", flagSchema)
 			datasetFolderPath := filepath.Join("assets", "templates", datasetFolder, schema)
 
 			templateFile := fmt.Sprintf("%s.tpl", templateType)
@@ -80,7 +80,12 @@ func TemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents)
+			timeNow, err := getTimeNowFromFlag(timeNowAsString)
+			if err != nil {
+				return err
+			}
+
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow)
 			if err != nil {
 				return err
 			}
@@ -94,6 +99,7 @@ func TemplateCmd() *cobra.Command {
 	command.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	command.Flags().StringVarP(&templateType, "engine", "e", "gotext", "either 'placeholder' or 'gotext'")
 	command.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
-	command.Flags().StringVarP(&flag_schema, "schema", "", "b", "schema to generate data for; valid values: a, b")
+	command.Flags().StringVarP(&flagSchema, "schema", "", "b", "schema to generate data for; valid values: a, b")
+	command.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
 	return command
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ You can pass a local Fields generation configuration file.
 
 `go run main.go generate <package> <dataset> <version> --tot-events <quantity>`
 
-`package`, `dataset` and `version` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`. 
+`package`, `dataset` and `version` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`. `--now` is not mandatory and in case it is provided must be a string parsable according the following `time.Parse()` layout: `2006-01-02T15:04:05.999999Z07:00`. The value provided will be used as base `time.Now()` for `date` type fields (see [Fields generation configuration](./fields-configuration.md#config-entries-definition))
 
 **Example**:
 
@@ -28,7 +28,7 @@ You can pass a local Fields generation configuration file.
 
 `go run main.go generate-with-template <template-path> <fields-definition-path> --tot-events <quantity>`
 
-`template-path` and `fields-definition-path` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`.
+`template-path` and `fields-definition-path` are mandatory. `--tot-events` is not mandatory and in case it is not provided a single event will be generated. You can generate an infinite number of events expressly passing to the flag the value of `0`. `--now` is not mandatory and in case it is provided must be a string parsable according the following `time.Parse()` layout: `2006-01-02T15:04:05.999999Z07:00`. The value provided will be used as base `time.Now()` for `date` type fields (see [Fields generation configuration](./fields-configuration.md#config-entries-definition))
 
 **Example**:
 

--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lithammer/shortuuid/v3"
 	"math/rand"
 	"strings"
+	"time"
 )
 
 const (
@@ -162,9 +163,9 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int) ([
 	return templateBuffer.Bytes(), objectKeysField
 }
 
-func NewGenerator(cfg Config, flds Fields, totEvents uint64) (Generator, error) {
+func NewGenerator(cfg Config, flds Fields, totEvents uint64, timeNow time.Time) (Generator, error) {
 	template, objectKeysField := generateCustomTemplateFromField(cfg, flds)
 	flds = append(flds, objectKeysField...)
 
-	return NewGeneratorWithCustomTemplate(template, cfg, flds, totEvents)
+	return NewGeneratorWithCustomTemplate(template, cfg, flds, totEvents, timeNow)
 }

--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -22,11 +22,7 @@ import (
 	"time"
 )
 
-var timeNow time.Time
-
-func init() {
-	timeNow = time.Now()
-}
+var timeNowToBind time.Time
 
 type (
 	Fields      = fields.Fields
@@ -510,7 +506,7 @@ func bindNearTime(fieldCfg ConfigField, field Field, fieldMap map[string]any) er
 			offset = time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
 		}
 
-		newTime := timeNow.Add(offset)
+		newTime := timeNowToBind.Add(offset)
 
 		buf.WriteString(newTime.Format(FieldTypeTimeLayout))
 		return nil
@@ -850,7 +846,7 @@ func bindNearTimeWithReturn(fieldCfg ConfigField, field Field, fieldMap map[stri
 			offset = time.Duration(rand.Intn(FieldTypeTimeRange)*-1) * time.Second
 		}
 
-		newTime := timeNow.Add(offset)
+		newTime := timeNowToBind.Add(offset)
 
 		return newTime
 	}

--- a/pkg/genlib/generator_test.go
+++ b/pkg/genlib/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib/config"
 	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib/fields"
@@ -15,7 +16,7 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 
 	template, objectKeysField := generateCustomTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
-	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(len(template)*b.N*1024))
+	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(len(template)*b.N*1024), time.Now())
 	defer func() {
 		_ = g.Close()
 	}()
@@ -44,7 +45,7 @@ func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 	template, objectKeysField := generateTextTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
 
-	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N*len(template)*1024))
+	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N*len(template)*1024), time.Now())
 	defer func() {
 		_ = g.Close()
 	}()
@@ -170,7 +171,7 @@ func Benchmark_GeneratorCustomTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{.Version}} {{.AccountID}} {{.InterfaceID}} {{.SrcAddr}} {{.DstAddr}} {{.SrcPort}} {{.DstPort}} {{.Protocol}} {{.Packets}} {{.Bytes}} {{.Start}} {{.End}} {{.Action}} {{.LogStatus}}`)
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(len(template)*b.N*1024))
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(len(template)*b.N*1024), time.Now())
 	defer func() {
 		_ = g.Close()
 	}()
@@ -296,7 +297,7 @@ func Benchmark_GeneratorTextTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{generate "Bytes"}} {{$start := generate "Start" }}{{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end := generate "End" }}{{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}`)
-	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N*len(template)*1024))
+	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N*len(template)*1024), time.Now())
 	defer func() {
 		_ = g.Close()
 	}()

--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 	"regexp"
+	"time"
 )
 
 type emitter struct {
@@ -82,7 +83,10 @@ func parseCustomTemplate(template []byte) ([]string, map[string][]byte, []byte) 
 
 }
 
-func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, totEvents uint64) (*GeneratorWithCustomTemplate, error) {
+func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, totEvents uint64, timeNow time.Time) (*GeneratorWithCustomTemplate, error) {
+	// set timeNowToBind to --now flag (already parsed or now)
+	timeNowToBind = timeNow
+
 	// Parse the template and extract relevant information
 	orderedFields, templateFieldsMap, trailingTemplate := parseCustomTemplate(template)
 

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -507,7 +507,7 @@ func Test_FieldDateAndPeriodWithCustomTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNow.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
+			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
 
 			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
 			if diff != 0 {
@@ -601,7 +601,7 @@ func testSingleTWithCustomTemplate[T any](t *testing.T, fld Field, yaml []byte, 
 }
 
 func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents)
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents, time.Now())
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
 )
@@ -49,7 +50,10 @@ var awsAZs map[string][]string = map[string][]string{
 	"us-west-2":      {"us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"},
 }
 
-func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEvents uint64) (*GeneratorWithTextTemplate, error) {
+func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEvents uint64, timeNow time.Time) (*GeneratorWithTextTemplate, error) {
+	// set timeNowToBind to --now flag (already parsed or now)
+	timeNowToBind = timeNow
+
 	// Preprocess the fields, generating appropriate bound function
 	state := NewGenState()
 	fieldMap := make(map[string]any)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -347,7 +347,7 @@ func Test_FieldDateAndPeriodWithTextTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNow.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
+			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
 
 			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
 			if diff != 0 {
@@ -441,7 +441,7 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 }
 
 func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents)
+	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents, time.Now())
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
In order to achieve deterministic reproducible output we add `--now` flag/`timeNow` arg to the generator
This way the user can provide a timestamp to use a "now time" of the generated value for date fields