### PR TITLE
Add seed flag

### DIFF
--- a/assets/templates/aws.ec2_logs/schema-b/fields.yml
+++ b/assets/templates/aws.ec2_logs/schema-b/fields.yml
@@ -1,4 +1,4 @@
-- name: timestamp
+- name: ts
   type: date
 - name: process.name
   type: keyword
@@ -12,8 +12,6 @@
   type: keyword
 - name: host.name
   type: keyword
-- name: aws.cloudwatch.ingestion_time
-  type: date
 - name: agent.id
   type: keyword
 - name: event.id

--- a/assets/templates/aws.ec2_logs/schema-b/gotext.tpl
+++ b/assets/templates/aws.ec2_logs/schema-b/gotext.tpl
@@ -1,4 +1,4 @@
-{{- $ts := now }}
+{{- $ts := generate "ts" }}
 {{- $ip := generate "aws.ec2.ip_address" }}
 {{- $pname := generate "process.name" }}
 {{- $logstream := generate "aws.cloudwatch.log_stream" }}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,7 +18,6 @@ import (
 var integrationPackage string
 var dataStream string
 var packageVersion string
-var timeNowAsString string
 
 func GenerateCmd() *cobra.Command {
 	generateCmd := &cobra.Command{
@@ -75,7 +74,7 @@ func GenerateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totEvents, timeNow)
+			payloadFilename, err := fc.Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion, totEvents, timeNow, randSeed)
 			if err != nil {
 				return err
 			}
@@ -90,5 +89,7 @@ func GenerateCmd() *cobra.Command {
 	generateCmd.Flags().StringVarP(&configFile, "config-file", "c", "", "path to config file for generator settings")
 	generateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	generateCmd.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
+	generateCmd.Flags().Int64VarP(&randSeed, "seed", "s", 1, "seed to set as source of rand")
+
 	return generateCmd
 }

--- a/cmd/generate_common.go
+++ b/cmd/generate_common.go
@@ -10,6 +10,8 @@ import (
 var packageRegistryBaseURL string
 var configFile string
 var totEvents uint64
+var timeNowAsString string
+var randSeed int64
 
 func getTimeNowFromFlag(timeNowAsString string) (time.Time, error) {
 	if len(timeNowAsString) > 0 {

--- a/cmd/generate_with_template.go
+++ b/cmd/generate_with_template.go
@@ -66,7 +66,7 @@ func GenerateWithTemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow)
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow, randSeed)
 			if err != nil {
 				return err
 			}
@@ -81,5 +81,7 @@ func GenerateWithTemplateCmd() *cobra.Command {
 	generateWithTemplateCmd.Flags().StringVarP(&templateType, "template-type", "y", "placeholder", "either 'placeholder' or 'gotext'")
 	generateWithTemplateCmd.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	generateWithTemplateCmd.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
+	generateWithTemplateCmd.Flags().Int64VarP(&randSeed, "seed", "s", 1, "seed to set as source of rand")
+
 	return generateWithTemplateCmd
 }

--- a/cmd/local-template.go
+++ b/cmd/local-template.go
@@ -85,7 +85,7 @@ func TemplateCmd() *cobra.Command {
 				return err
 			}
 
-			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow)
+			payloadFilename, err := fc.GenerateWithTemplate(templatePath, fieldsDefinitionPath, totEvents, timeNow, randSeed)
 			if err != nil {
 				return err
 			}
@@ -101,5 +101,7 @@ func TemplateCmd() *cobra.Command {
 	command.Flags().Uint64VarP(&totEvents, "tot-events", "t", 1, "total events of the corpus to generate")
 	command.Flags().StringVarP(&flagSchema, "schema", "", "b", "schema to generate data for; valid values: a, b")
 	command.Flags().StringVarP(&timeNowAsString, "now", "n", "", "time to use for generation based on now (`date` type)")
+
+	command.Flags().Int64VarP(&randSeed, "seed", "s", 1, "seed to set as source of rand")
 	return command
 }

--- a/internal/corpus/generator.go
+++ b/internal/corpus/generator.go
@@ -106,17 +106,19 @@ func (gc GeneratorCorpus) bulkPayloadFilenameWithTemplate(templatePath string) s
 var corpusLocPerm = os.FileMode(0770)
 var corpusPerm = os.FileMode(0660)
 
-func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields, totEvents uint64, timeNow time.Time, createPayload []byte, f afero.File) error {
+func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields, totEvents uint64, timeNow time.Time, randSeed int64, createPayload []byte, f afero.File) error {
+	genlib.GeneratorTimeNow(timeNow)
+	genlib.GeneratorRandSeed(randSeed)
 
 	var evgen genlib.Generator
 	var err error
 	if len(template) == 0 {
-		evgen, err = genlib.NewGenerator(gc.config, fields, totEvents, timeNow)
+		evgen, err = genlib.NewGenerator(gc.config, fields, totEvents)
 	} else {
 		if gc.templateType == templateTypeCustom {
-			evgen, err = genlib.NewGeneratorWithCustomTemplate(template, gc.config, fields, totEvents, timeNow)
+			evgen, err = genlib.NewGeneratorWithCustomTemplate(template, gc.config, fields, totEvents)
 		} else if gc.templateType == templateTypeGoText {
-			evgen, err = genlib.NewGeneratorWithTextTemplate(template, gc.config, fields, totEvents, timeNow)
+			evgen, err = genlib.NewGeneratorWithTextTemplate(template, gc.config, fields, totEvents)
 		} else {
 			return ErrNotValidTemplate
 		}
@@ -162,7 +164,7 @@ func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields
 }
 
 // Generate generates a bulk request corpus and persist it to file.
-func (gc GeneratorCorpus) Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion string, totEvents uint64, timeNow time.Time) (string, error) {
+func (gc GeneratorCorpus) Generate(packageRegistryBaseURL, integrationPackage, dataStream, packageVersion string, totEvents uint64, timeNow time.Time, randSeed int64) (string, error) {
 	if err := gc.fs.MkdirAll(gc.location, corpusLocPerm); err != nil {
 		return "", fmt.Errorf("cannot generate corpus location folder: %v", err)
 	}
@@ -181,7 +183,7 @@ func (gc GeneratorCorpus) Generate(packageRegistryBaseURL, integrationPackage, d
 
 	createPayload := []byte(`{ "create" : { "_index": "` + dataStreamType + `-` + integrationPackage + `.` + dataStream + `-default" } }` + "\n")
 
-	err = gc.eventsPayloadFromFields(nil, flds, totEvents, timeNow, createPayload, f)
+	err = gc.eventsPayloadFromFields(nil, flds, totEvents, timeNow, randSeed, createPayload, f)
 	if err != nil {
 		return "", err
 	}
@@ -194,7 +196,7 @@ func (gc GeneratorCorpus) Generate(packageRegistryBaseURL, integrationPackage, d
 }
 
 // GenerateWithTemplate generates a template based corpus and persist it to file.
-func (gc GeneratorCorpus) GenerateWithTemplate(templatePath, fieldsDefinitionPath string, totEvents uint64, timeNow time.Time) (string, error) {
+func (gc GeneratorCorpus) GenerateWithTemplate(templatePath, fieldsDefinitionPath string, totEvents uint64, timeNow time.Time, randSeed int64) (string, error) {
 	if err := gc.fs.MkdirAll(gc.location, corpusLocPerm); err != nil {
 		return "", fmt.Errorf("cannot generate corpus location folder: %v", err)
 	}
@@ -220,7 +222,7 @@ func (gc GeneratorCorpus) GenerateWithTemplate(templatePath, fieldsDefinitionPat
 		return "", err
 	}
 
-	err = gc.eventsPayloadFromFields(template, flds, totEvents, timeNow, nil, f)
+	err = gc.eventsPayloadFromFields(template, flds, totEvents, timeNow, randSeed, nil, f)
 	if err != nil {
 		return "", err
 	}

--- a/internal/corpus/generator.go
+++ b/internal/corpus/generator.go
@@ -107,8 +107,8 @@ var corpusLocPerm = os.FileMode(0770)
 var corpusPerm = os.FileMode(0660)
 
 func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields, totEvents uint64, timeNow time.Time, randSeed int64, createPayload []byte, f afero.File) error {
-	genlib.GeneratorTimeNow(timeNow)
-	genlib.GeneratorRandSeed(randSeed)
+	genlib.InitGeneratorTimeNow(timeNow)
+	genlib.InitGeneratorRandSeed(randSeed)
 
 	var evgen genlib.Generator
 	var err error

--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -163,9 +163,22 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int) ([
 	return templateBuffer.Bytes(), objectKeysField
 }
 
-func NewGenerator(cfg Config, flds Fields, totEvents uint64, timeNow time.Time) (Generator, error) {
+func NewGenerator(cfg Config, flds Fields, totEvents uint64) (Generator, error) {
 	template, objectKeysField := generateCustomTemplateFromField(cfg, flds)
 	flds = append(flds, objectKeysField...)
 
-	return NewGeneratorWithCustomTemplate(template, cfg, flds, totEvents, timeNow)
+	return NewGeneratorWithCustomTemplate(template, cfg, flds, totEvents)
+}
+
+// InitGeneratorTimeNow sets base timeNow for `date` field
+func InitGeneratorTimeNow(timeNow time.Time) {
+	// set timeNowToBind to --now flag (already parsed or now)
+	timeNowToBind = timeNow
+}
+
+// InitGeneratorRandSeed sets rand seed
+func InitGeneratorRandSeed(randSeed int64) {
+	// set rand and randomdata seed to --seed flag (custom or 1)
+	rand.Seed(randSeed)
+	randomdata.CustomRand(rand.New(rand.NewSource(randSeed)))
 }

--- a/pkg/genlib/generator_test.go
+++ b/pkg/genlib/generator_test.go
@@ -3,11 +3,9 @@ package genlib
 import (
 	"bytes"
 	"context"
-	"testing"
-	"time"
-
 	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib/config"
 	"github.com/elastic/elastic-integration-corpus-generator-tool/pkg/genlib/fields"
+	"testing"
 )
 
 func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
@@ -16,7 +14,7 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 
 	template, objectKeysField := generateCustomTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
-	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(len(template)*b.N*1024), time.Now())
+	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(len(template)*b.N*1024))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -45,7 +43,7 @@ func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 	template, objectKeysField := generateTextTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
 
-	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N*len(template)*1024), time.Now())
+	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N*len(template)*1024))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -171,7 +169,7 @@ func Benchmark_GeneratorCustomTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{.Version}} {{.AccountID}} {{.InterfaceID}} {{.SrcAddr}} {{.DstAddr}} {{.SrcPort}} {{.DstPort}} {{.Protocol}} {{.Packets}} {{.Bytes}} {{.Start}} {{.End}} {{.Action}} {{.LogStatus}}`)
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(len(template)*b.N*1024), time.Now())
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(len(template)*b.N*1024))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -297,7 +295,7 @@ func Benchmark_GeneratorTextTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{generate "Bytes"}} {{$start := generate "Start" }}{{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end := generate "End" }}{{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}`)
-	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N*len(template)*1024), time.Now())
+	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N*len(template)*1024))
 	defer func() {
 		_ = g.Close()
 	}()

--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io"
 	"regexp"
-	"time"
 )
 
 type emitter struct {
@@ -83,10 +82,7 @@ func parseCustomTemplate(template []byte) ([]string, map[string][]byte, []byte) 
 
 }
 
-func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, totEvents uint64, timeNow time.Time) (*GeneratorWithCustomTemplate, error) {
-	// set timeNowToBind to --now flag (already parsed or now)
-	timeNowToBind = timeNow
-
+func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, totEvents uint64) (*GeneratorWithCustomTemplate, error) {
 	// Parse the template and extract relevant information
 	orderedFields, templateFieldsMap, trailingTemplate := parseCustomTemplate(template)
 

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -601,7 +601,7 @@ func testSingleTWithCustomTemplate[T any](t *testing.T, fld Field, yaml []byte, 
 }
 
 func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents, time.Now())
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -7,12 +7,10 @@ package genlib
 import (
 	"bytes"
 	"errors"
+	"github.com/Masterminds/sprig/v3"
 	"io"
 	"math/rand"
 	"text/template"
-	"time"
-
-	"github.com/Masterminds/sprig/v3"
 )
 
 var generateOnFieldNotInFieldsYaml = errors.New("generate called on a field not present in fields yaml definition")
@@ -50,10 +48,7 @@ var awsAZs map[string][]string = map[string][]string{
 	"us-west-2":      {"us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"},
 }
 
-func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEvents uint64, timeNow time.Time) (*GeneratorWithTextTemplate, error) {
-	// set timeNowToBind to --now flag (already parsed or now)
-	timeNowToBind = timeNow
-
+func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEvents uint64) (*GeneratorWithTextTemplate, error) {
 	// Preprocess the fields, generating appropriate bound function
 	state := NewGenState()
 	fieldMap := make(map[string]any)

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -441,7 +441,7 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 }
 
 func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
-	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents, time.Now())
+	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We add a `--seed` flag to feed the rand seed used in pkg and by go-randomdata dependecy.

`timeNow` and `randSeed` are moved to their init functions in pkg instead of passed to the generator factories

`aws.ec2_logs` assets have been refactored so to achieve reproducible generation given the same `--now` and `--seed` value