### PR TITLE
Do not expose GenState

### DIFF
--- a/internal/corpus/generator.go
+++ b/internal/corpus/generator.go
@@ -129,8 +129,6 @@ func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields
 		return err
 	}
 
-	state := genlib.NewGenState()
-
 	var buf *bytes.Buffer
 	if len(template) == 0 {
 		buf = bytes.NewBuffer(createPayload)
@@ -144,7 +142,7 @@ func (gc GeneratorCorpus) eventsPayloadFromFields(template []byte, fields Fields
 
 	for {
 		buf.Truncate(len(createPayload))
-		err := evgen.Emit(state, buf)
+		err := evgen.Emit(buf)
 		if err == nil {
 			buf.WriteByte('\n')
 

--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -65,7 +65,8 @@ type emitFNotReturn func(state *GenState, buf *bytes.Buffer) error
 type EmitF func(state *GenState) any
 
 type Generator interface {
-	Emit(state *GenState, buf *bytes.Buffer) error
+	Emit(buf *bytes.Buffer) error
+	GenState() *GenState
 	Close() error
 }
 
@@ -84,7 +85,7 @@ type GenState struct {
 	pool sync.Pool
 }
 
-func NewGenState() *GenState {
+func newGenState() *GenState {
 	return &GenState{
 		prevCache:            make(map[string]any),
 		prevCacheForDup:      make(map[string]map[any]struct{}),

--- a/pkg/genlib/generator_test.go
+++ b/pkg/genlib/generator_test.go
@@ -29,7 +29,7 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 
 	template, objectKeysField := generateCustomTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
-	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(len(template)*b.N*1024))
+	g, err := NewGeneratorWithCustomTemplate(template, Config{}, flds, uint64(b.N))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -40,10 +40,9 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 
 	var buf bytes.Buffer
 
-	state := NewGenState()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := g.Emit(state, &buf)
+		err := g.Emit(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -58,7 +57,7 @@ func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 	template, objectKeysField := generateTextTemplateFromField(Config{}, flds)
 	flds = append(flds, objectKeysField...)
 
-	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N*len(template)*1024))
+	g, err := NewGeneratorWithTextTemplate(template, Config{}, flds, uint64(b.N))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -69,10 +68,9 @@ func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 
 	var buf bytes.Buffer
 
-	state := NewGenState()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := g.Emit(state, &buf)
+		err := g.Emit(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -184,7 +182,7 @@ func Benchmark_GeneratorCustomTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{.Version}} {{.AccountID}} {{.InterfaceID}} {{.SrcAddr}} {{.DstAddr}} {{.SrcPort}} {{.DstPort}} {{.Protocol}} {{.Packets}} {{.Bytes}} {{.Start}} {{.End}} {{.Action}} {{.LogStatus}}`)
-	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(len(template)*b.N*1024))
+	g, err := NewGeneratorWithCustomTemplate(template, cfg, flds, uint64(b.N))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -195,10 +193,9 @@ func Benchmark_GeneratorCustomTemplateVPCFlowLogs(b *testing.B) {
 
 	var buf bytes.Buffer
 
-	state := NewGenState()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := g.Emit(state, &buf)
+		err := g.Emit(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -310,7 +307,7 @@ func Benchmark_GeneratorTextTemplateVPCFlowLogs(b *testing.B) {
 	}
 
 	template := []byte(`{{generate "Version"}} {{generate "AccountID"}} {{generate "InterfaceID"}} {{generate "SrcAddr"}} {{generate "DstAddr"}} {{generate "SrcPort"}} {{generate "DstPort"}} {{generate "Protocol"}}{{ $packets := generate "Packets" }} {{ $packets }} {{generate "Bytes"}} {{$start := generate "Start" }}{{$start.Format "2006-01-02T15:04:05.999999Z07:00" }} {{$end := generate "End" }}{{$end.Format "2006-01-02T15:04:05.999999Z07:00"}} {{generate "Action"}}{{ if eq $packets 0 }} NODATA {{ else }} {{generate "LogStatus"}} {{ end }}`)
-	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N*len(template)*1024))
+	g, err := NewGeneratorWithTextTemplate(template, cfg, flds, uint64(b.N))
 	defer func() {
 		_ = g.Close()
 	}()
@@ -321,10 +318,9 @@ func Benchmark_GeneratorTextTemplateVPCFlowLogs(b *testing.B) {
 
 	var buf bytes.Buffer
 
-	state := NewGenState()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := g.Emit(state, &buf)
+		err := g.Emit(&buf)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -87,7 +87,7 @@ func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, 
 	orderedFields, templateFieldsMap, trailingTemplate := parseCustomTemplate(template)
 
 	// Preprocess the fields, generating appropriate emit functions
-	state := NewGenState()
+	state := newGenState()
 	fieldMap := make(map[string]any)
 	fieldTypes := make(map[string]string)
 	for _, field := range fields {
@@ -116,26 +116,29 @@ func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, 
 	return &GeneratorWithCustomTemplate{emitters: emitters, trailingTemplate: trailingTemplate, totEvents: totEvents, state: state}, nil
 }
 
-func (gen GeneratorWithCustomTemplate) Close() error {
+func (gen *GeneratorWithCustomTemplate) Close() error {
 	return nil
 }
 
-func (gen GeneratorWithCustomTemplate) Emit(state *GenState, buf *bytes.Buffer) error {
-	state = gen.state
-	if err := gen.emit(state, buf); err != nil {
+func (gen *GeneratorWithCustomTemplate) GenState() *GenState {
+	return gen.state
+}
+
+func (gen *GeneratorWithCustomTemplate) Emit(buf *bytes.Buffer) error {
+	if err := gen.emit(buf); err != nil {
 		return err
 	}
 
-	state.counter += 1
+	gen.state.counter += 1
 
 	return nil
 }
 
-func (gen GeneratorWithCustomTemplate) emit(state *GenState, buf *bytes.Buffer) error {
-	if gen.totEvents == 0 || state.counter < gen.totEvents {
+func (gen *GeneratorWithCustomTemplate) emit(buf *bytes.Buffer) error {
+	if gen.totEvents == 0 || gen.state.counter < gen.totEvents {
 		for _, e := range gen.emitters {
 			buf.Write(e.prefix)
-			if err := e.emitFunc(state, buf); err != nil {
+			if err := e.emitFunc(gen.state, buf); err != nil {
 				return err
 			}
 		}

--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -22,7 +22,7 @@ type GeneratorWithCustomTemplate struct {
 	totEvents        uint64
 	emitters         []emitter
 	trailingTemplate []byte
-	state            *GenState
+	state            *genState
 }
 
 func parseCustomTemplate(template []byte) ([]string, map[string][]byte, []byte) {
@@ -118,10 +118,6 @@ func NewGeneratorWithCustomTemplate(template []byte, cfg Config, fields Fields, 
 
 func (gen *GeneratorWithCustomTemplate) Close() error {
 	return nil
-}
-
-func (gen *GeneratorWithCustomTemplate) GenState() *GenState {
-	return gen.state
 }
 
 func (gen *GeneratorWithCustomTemplate) Emit(buf *bytes.Buffer) error {

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -179,11 +179,11 @@ func Test_ParseTemplate(t *testing.T) {
 func Test_EmptyCaseWithCustomTemplate(t *testing.T) {
 	template, _ := generateCustomTemplateFromField(Config{}, []Field{})
 	t.Logf("with template: %s", string(template))
-	g, state := makeGeneratorWithCustomTemplate(t, Config{}, []Field{}, template, 0)
+	g := makeGeneratorWithCustomTemplate(t, Config{}, []Field{}, template, 0)
 
 	var buf bytes.Buffer
 
-	if err := g.Emit(state, &buf); err != nil {
+	if err := g.Emit(&buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -242,7 +242,7 @@ func test_CardinalityTWithCustomTemplate[T any](t *testing.T, ty string) {
 		}
 
 		nSpins := 16384
-		g, state := makeGeneratorWithCustomTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(len(template)*nSpins*1024))
+		g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(len(template)*nSpins*1024))
 
 		vmapAlpha := make(map[any]int)
 		vmapBeta := make(map[any]int)
@@ -250,7 +250,7 @@ func test_CardinalityTWithCustomTemplate[T any](t *testing.T, ty string) {
 		for i := 0; i < nSpins; i++ {
 
 			var buf bytes.Buffer
-			if err := g.Emit(state, &buf); err != nil {
+			if err := g.Emit(&buf); err != nil {
 				t.Fatal(err)
 			}
 
@@ -480,13 +480,13 @@ func Test_FieldDateAndPeriodWithCustomTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g, state := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
 
 	var buf bytes.Buffer
 
 	nSpins := 10
 	for i := 0; i < nSpins; i++ {
-		if err := g.Emit(state, &buf); err != nil {
+		if err := g.Emit(&buf); err != nil {
 			t.Fatal(err)
 		}
 
@@ -575,11 +575,11 @@ func testSingleTWithCustomTemplate[T any](t *testing.T, fld Field, yaml []byte, 
 		}
 	}
 
-	g, state := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 0)
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 0)
 
 	var buf bytes.Buffer
 
-	if err := g.Emit(state, &buf); err != nil {
+	if err := g.Emit(&buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -600,12 +600,12 @@ func testSingleTWithCustomTemplate[T any](t *testing.T, fld Field, yaml []byte, 
 	return v
 }
 
-func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
+func makeGeneratorWithCustomTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) Generator {
 	g, err := NewGeneratorWithCustomTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return g, NewGenState()
+	return g
 }

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -18,7 +18,7 @@ var generateOnFieldNotInFieldsYaml = errors.New("generate called on a field not 
 // GeneratorWithTextTemplate
 type GeneratorWithTextTemplate struct {
 	tpl       *template.Template
-	state     *GenState
+	state     *genState
 	errChan   chan error
 	totEvents uint64
 }
@@ -99,10 +99,6 @@ func NewGeneratorWithTextTemplate(tpl []byte, cfg Config, fields Fields, totEven
 
 func (gen *GeneratorWithTextTemplate) Close() error {
 	return nil
-}
-
-func (gen *GeneratorWithTextTemplate) GenState() *GenState {
-	return gen.state
 }
 
 func (gen *GeneratorWithTextTemplate) Emit(buf *bytes.Buffer) error {

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -16,11 +16,11 @@ import (
 func Test_EmptyCaseWithTextTemplate(t *testing.T) {
 	template, _ := generateTextTemplateFromField(Config{}, []Field{})
 	t.Logf("with template: %s", string(template))
-	g, state := makeGeneratorWithTextTemplate(t, Config{}, []Field{}, template, 0)
+	g := makeGeneratorWithTextTemplate(t, Config{}, []Field{}, template, 0)
 
 	var buf bytes.Buffer
 
-	if err := g.Emit(state, &buf); err != nil {
+	if err := g.Emit(&buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +81,7 @@ func test_CardinalityTWithTextTemplate[T any](t *testing.T, ty string) {
 		}
 
 		nSpins := 16384
-		g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(nSpins))
+		g := makeGeneratorWithTextTemplate(t, cfg, []Field{fldAlpha, fldBeta}, template, uint64(nSpins))
 
 		vmapAlpha := make(map[any]int)
 		vmapBeta := make(map[any]int)
@@ -89,7 +89,7 @@ func test_CardinalityTWithTextTemplate[T any](t *testing.T, ty string) {
 		for i := 0; i < nSpins; i++ {
 
 			var buf bytes.Buffer
-			if err := g.Emit(state, &buf); err != nil {
+			if err := g.Emit(&buf); err != nil {
 				t.Fatal(err)
 			}
 
@@ -320,13 +320,13 @@ func Test_FieldDateAndPeriodWithTextTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
 
 	var buf bytes.Buffer
 
 	nSpins := 10
 	for i := 0; i < nSpins; i++ {
-		if err := g.Emit(state, &buf); err != nil {
+		if err := g.Emit(&buf); err != nil {
 			t.Fatal(err)
 		}
 
@@ -415,11 +415,11 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 		}
 	}
 
-	g, state := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 0)
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 0)
 
 	var buf bytes.Buffer
 
-	if err := g.Emit(state, &buf); err != nil {
+	if err := g.Emit(&buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -440,12 +440,12 @@ func testSingleTWithTextTemplate[T any](t *testing.T, fld Field, yaml []byte, te
 	return v
 }
 
-func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) (Generator, *GenState) {
+func makeGeneratorWithTextTemplate(t *testing.T, cfg Config, fields Fields, template []byte, totEvents uint64) Generator {
 	g, err := NewGeneratorWithTextTemplate(template, cfg, fields, totEvents)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return g, NewGenState()
+	return g
 }


### PR DESCRIPTION
`GenState` was initially owned and initialized by the invoker of the generator library.
More or less since the introduction of the template engines, the state of the generator is owned by the generator instance itself, but still it was passed to the `Generator.Emit()` method that would override the state passed by the invoker.
This is counter intuitive and could lead in the wrong assumption from the generator consumer about the ownership of the state.
This PR removes passing the state to `Generator.Emit()` and makes the state and its factory (`GenState`, `NewGenState()`) private