### PR TITLE
Range from to for date type

### DIFF
--- a/docs/fields-configuration.md
+++ b/docs/fields-configuration.md
@@ -12,8 +12,9 @@ For each config entry the following fields are available:
 - `name` *mandatory*: dotted path field, matching an entry in [Fields definition](./glossary.md#fields-definition)
 - `fuzziness` *optional (`long` and `double` type only)*: when generating data you could want generated values to change in a known interval. Fuzziness allow to specify the maximum delta a generated value can have from the previous value (for the same field), as a delta percentage; value must be between 0.0 and 1.0, where 0 is 0% and 1 is 100%. When not specified there is no constraint on the generated values, boundaries will be defined by the underlying field type
 - `range` *optional (`long` and `double` type only)*: value will be generated between `min` and `max`
+- `range` *optional (`date` type only)*: value will be generated between `from` and `to`. Only one between `from` and `to` can be set, in this case the dates will be generated between `from`/`to` and `time.Now()`. Progressive order of the generated dates is always assured regardless the interval involving `from`, `to` and `time.Now()` is positive or negative. This setting has preference over `period`. 
 - `cardinality` *optional*: number of different values for the field; note that this value may not be respected if not enough events are generated. Es `cardinality: 1000` with `100` generated events would produce `100` different values, not `1000`.
-- `period` *optional (`date` type only)*: values will be evenly generated between `time.Now()` and `time.Now().Add(period)`, where period is expressed as `time.Duration`. It accepts also a negative duration: in this case  values will be evenly generated between `time.Now().Add(period)` and `time.Now()`.
+- `period` *optional (`date` type only)*: values will be evenly generated between `time.Now()` and `time.Now().Add(period)`, where period is expressed as `time.Duration`. It accepts also a negative duration: in this case  values will be evenly generated between `time.Now().Add(period)` and `time.Now()`. This setting is ignored if a `range` with `from`/`to` is configured.
 - `object_keys` *optional (`object` type only)*: list of field names to generate in a object field type; if not specified a random number of field names will be generated in the object filed type
 - `value` *optional*: hardcoded value to set for the field (any `cardinality` will be ignored)
 - `enum` *optional (`keyword` type only)*: list of strings to randomly chose from a value to set for the field (any `cardinality` will be applied limited to the size of the `enum` values)
@@ -26,6 +27,10 @@ If you have an `object` type field that you defined one or multiple `object_keys
 fields:
   - name: timestamp
     period: "1h"
+  - name: lastSnapshot
+    range:
+      from: "2023-11-23-11:29:48Z"
+      to: "2023-12-13-01:39:58Z"
   - name: aws.dynamodb.metrics.AccountMaxReads.max
     fuzziness: 0.1
     range:
@@ -60,6 +65,8 @@ fields:
 Related [fields definition](./writing-templates.md#fieldsyml---fields-definition)
 ```yaml
 - name: timestamp
+  type: date
+- name: lastSnapshot
   type: date
 - name: data_stream.type
   type: constant_keyword

--- a/pkg/genlib/config/config.go
+++ b/pkg/genlib/config/config.go
@@ -12,11 +12,24 @@ import (
 )
 
 var rangeBoundNotSet = errors.New("range bound not set")
+var rangeTimeNotSet = errors.New("range time not set")
+
+type TimeRange struct {
+	time.Time
+}
+
+func (ct *TimeRange) Unpack(t string) error {
+	var err error
+	ct.Time, err = time.Parse(time.RFC3339Nano, t)
+	return err
+}
 
 type Range struct {
-	// NOTE: we want to distinguish when Min/Max are explicitly set to zero value or are not set at all. We use a pointer, such that when not set will be `nil`.
-	Min *float64 `config:"min"`
-	Max *float64 `config:"max"`
+	// NOTE: we want to distinguish when Min/Max/From/To are explicitly set to zero value or are not set at all. We use a pointer, such that when not set will be `nil`.
+	Min  *float64   `config:"min"`
+	Max  *float64   `config:"max"`
+	From *TimeRange `config:"from"`
+	To   *TimeRange `config:"to"`
 }
 
 type Config struct {
@@ -32,6 +45,22 @@ type ConfigField struct {
 	Enum        []string      `config:"enum"`
 	ObjectKeys  []string      `config:"object_keys"`
 	Value       any           `config:"value"`
+}
+
+func (r Range) FromAsTime() (time.Time, error) {
+	if r.From == nil {
+		return time.Time{}, rangeTimeNotSet
+	}
+
+	return r.From.Time, nil
+}
+
+func (r Range) ToAsTime() (time.Time, error) {
+	if r.To == nil {
+		return time.Time{}, rangeTimeNotSet
+	}
+
+	return r.To.Time, nil
 }
 
 func (r Range) MinAsInt64() (int64, error) {

--- a/pkg/genlib/config/config_test.go
+++ b/pkg/genlib/config/config_test.go
@@ -259,6 +259,112 @@ func TestRange_MinAsInt64(t *testing.T) {
 	}
 }
 
+func TestRange_FromAsTime(t *testing.T) {
+	from, err := time.Parse("2006-01-02T15:04:05Z", "2023-11-23T08:35:38Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  time.Time
+		hasError  bool
+	}{
+		{
+			scenario:  "from nil",
+			rangeYaml: "to: 2023-11-23T08:35:38Z",
+			expected:  time.Time{},
+			hasError:  true,
+		},
+		{
+			scenario:  "from not nil",
+			rangeYaml: "from: 2023-11-23T08:35:38Z",
+			expected:  from,
+			hasError:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.FromAsTime()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}
+
+func TestRange_ToAsTime(t *testing.T) {
+	to, err := time.Parse("2006-01-02T15:04:05Z", "2023-11-23T08:35:38Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		scenario  string
+		rangeYaml string
+		expected  time.Time
+		hasError  bool
+	}{
+		{
+			scenario:  "to nil",
+			rangeYaml: "from: 2023-11-23T08:35:38Z",
+			expected:  time.Time{},
+			hasError:  true,
+		},
+		{
+			scenario:  "to not nil",
+			rangeYaml: "to: 2023-11-23T08:35:38Z",
+			expected:  to,
+			hasError:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			cfg, err := yaml.NewConfig([]byte(testCase.rangeYaml))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var rangeCfg Range
+			err = cfg.Unpack(&rangeCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := rangeCfg.ToAsTime()
+			if testCase.hasError && err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if !testCase.hasError && err != nil {
+				t.Fatal("expected no error but got one")
+			}
+			if testCase.expected != v {
+				t.Fatalf("expected %v, got %v", testCase.expected, v)
+			}
+		})
+	}
+}
+
 func TestPeriod(t *testing.T) {
 	testCases := []struct {
 		scenario   string

--- a/pkg/genlib/generator_with_custom_template_test.go
+++ b/pkg/genlib/generator_with_custom_template_test.go
@@ -502,9 +502,9 @@ func Test_FieldDateAndPeriodPositiveWithCustomTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
+			expectedTime := timeNowToBind.Add(time.Second * time.Duration(i))
 
-			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
+			diff := expectedTime.Sub(ts)
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}
@@ -554,9 +554,341 @@ func Test_FieldDateAndPeriodNegativeWithCustomTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(-10*time.Second + time.Second*time.Duration(i))
+			expectedTime := timeNowToBind.Add(-10*time.Second + time.Second*time.Duration(i))
 
-			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromInThePastWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s", from.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := timeNowToBind.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromInTheFutureWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s", from.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := from.UTC().Sub(timeNowToBind.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeToInThePastWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	to := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      to: %s", to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := timeNowToBind.UTC().Sub(to.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeToInTheFutureWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	to := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      to: %s", to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(timeNowToBind.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromAndToPositiveWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(-10 * time.Second)
+	to := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s\n      to: %s", from.Format("2006-01-02T15:04:05.999999Z07:00"), to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := from.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromAndToNegativeWithCustomTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(10 * time.Second)
+	to := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{"alpha":"{{.alpha}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s\n      to: %s", from.Format("2006-01-02T15:04:05.999999Z07:00"), to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithCustomTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := from.Add(time.Duration((period.Nanoseconds() / nSpins) * (nSpins - i)))
+
+			diff := expectedTime.Sub(ts)
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}

--- a/pkg/genlib/generator_with_text_template_test.go
+++ b/pkg/genlib/generator_with_text_template_test.go
@@ -342,9 +342,9 @@ func Test_FieldDateAndPeriodPositiveWithTextTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(time.Second * time.Duration(i))
+			expectedTime := timeNowToBind.Add(time.Second * time.Duration(i))
 
-			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
+			diff := expectedTime.Sub(ts)
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}
@@ -394,9 +394,341 @@ func Test_FieldDateAndPeriodNegativeWithTextTemplate(t *testing.T) {
 			t.Errorf("Fail parse timestamp %v", err)
 		} else {
 			// Timestamp should be +1s for every iteration
-			expectedTime := timeNowToBind.Truncate(time.Millisecond).Add(-10*time.Second + time.Second*time.Duration(i))
+			expectedTime := timeNowToBind.Add(-10*time.Second + time.Second*time.Duration(i))
 
-			diff := expectedTime.Sub(ts.Truncate(time.Millisecond))
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromInThePastWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s", from.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := timeNowToBind.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromInTheFutureWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s", from.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := from.UTC().Sub(timeNowToBind.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeToInThePastWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	to := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      to: %s", to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := timeNowToBind.UTC().Sub(to.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeToInTheFutureWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	to := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      to: %s", to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(timeNowToBind.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := timeNowToBind.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromAndToPositiveWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(-10 * time.Second)
+	to := timeNowToBind.Add(10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s\n      to: %s", from.Format("2006-01-02T15:04:05.999999Z07:00"), to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := from.Add(time.Duration((period.Nanoseconds() / nSpins) * i))
+
+			diff := expectedTime.Sub(ts)
+			if diff != 0 {
+				t.Errorf("Date generated out of period range %v", diff)
+			}
+		}
+	}
+}
+
+func Test_FieldDateAndRangeFromAndToNegativeWithTextTemplate(t *testing.T) {
+	fld := Field{
+		Name: "alpha",
+		Type: FieldTypeDate,
+	}
+
+	from := timeNowToBind.Add(10 * time.Second)
+	to := timeNowToBind.Add(-10 * time.Second)
+	template := []byte(`{{$alpha := generate "alpha"}}{"alpha":"{{$alpha.Format "2006-01-02T15:04:05.999999Z07:00"}}"}`)
+	configYaml := []byte(fmt.Sprintf("fields:\n  - name: alpha\n    range:\n      from: %s\n      to: %s", from.Format("2006-01-02T15:04:05.999999Z07:00"), to.Format("2006-01-02T15:04:05.999999Z07:00")))
+	t.Logf("with template: %s", string(template))
+
+	cfg, err := config.LoadConfigFromYaml(configYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := makeGeneratorWithTextTemplate(t, cfg, []Field{fld}, template, 10)
+
+	var buf bytes.Buffer
+
+	period := to.UTC().Sub(from.UTC())
+
+	nSpins := int64(10)
+	for i := int64(0); i < nSpins; i++ {
+		if err := g.Emit(&buf); err != nil {
+			t.Fatal(err)
+		}
+
+		m := unmarshalJSONT[string](t, buf.Bytes())
+		buf.Reset()
+
+		if len(m) != 1 {
+			t.Errorf("Expected map size 1, got %d", len(m))
+		}
+
+		v, ok := m[fld.Name]
+
+		if !ok {
+			t.Errorf("Missing key %v", fld.Name)
+		}
+
+		if ts, err := time.Parse(FieldTypeTimeLayout, v); err != nil {
+			t.Errorf("Fail parse timestamp %v", err)
+		} else {
+			// Timestamp should be +(period.Nanoseconds() / nSpins) * i) for every iteration
+			expectedTime := from.Add(time.Duration((period.Nanoseconds() / nSpins) * (nSpins - i)))
+
+			diff := expectedTime.Sub(ts)
 			if diff != 0 {
 				t.Errorf("Date generated out of period range %v", diff)
 			}


### PR DESCRIPTION
We want to be able to generate date fields between a range.
We introduce `range.from` and `range.to` config settings that will be considered only for date fields.
It is possible to specify both `from` and `to` or only one of them.
If both are specified, the dates will be generate between `from` and `to`
If only one is specified, the dates will be generated in the interval given by either `from` or `to` and `time.Now()`
In any case the dates generated will keep progressive order, regardless the interval is negative of positive.
