### PR TITLE
fix: long/double enum type assertion failure in gotext templates

### DIFF
--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -1064,7 +1064,8 @@ func bindLongWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string]a
 	}
 
 	if len(fieldCfg.Enum) > 0 {
-		emitF := func(state *genState) any {
+		var emitF emitF
+		emitF = func(state *genState) any {
 			idx := state.rand.Intn(len(fieldCfg.Enum))
 			f, _ := strconv.ParseInt(fieldCfg.Enum[idx], 10, 64)
 			return f
@@ -1223,7 +1224,8 @@ func bindDoubleWithReturn(fieldCfg ConfigField, field Field, fieldMap map[string
 	}
 
 	if len(fieldCfg.Enum) > 0 {
-		emitF := func(state *genState) any {
+		var emitF emitF
+		emitF = func(state *genState) any {
 			idx := state.rand.Intn(len(fieldCfg.Enum))
 			f, _ := strconv.ParseFloat(fieldCfg.Enum[idx], 64)
 			return f


### PR DESCRIPTION
## Summary

Fixes a runtime panic when using `enum` with `long` or `double` fields in gotext templates (`-y gotext`).

Closes #179 

## Fix

Use explicit named type declaration:

```go
var emitF emitF
emitF = func(state *genState) any { ... }
```

Applied to both `bindLongWithReturn` and `bindDoubleWithReturn`.