### PR TITLE
fix: trim excess capacity from normaliseFields return value

### DIFF
--- a/pkg/genlib/fields/fields.go
+++ b/pkg/genlib/fields/fields.go
@@ -81,5 +81,11 @@ func normaliseFields(fields Fields) (Fields, error) {
 	}
 
 	sort.Sort(normalisedFields)
+	// Trim excess capacity so that callers sharing this slice across goroutines
+	// cannot inadvertently share the backing array when they append to it.
+	// normaliseFields allocates cap=len(fields) but may keep fewer entries when
+	// wildcard fields are filtered; without this trim the surplus capacity is
+	// a latent data-race vector (see fbxj-vtfy-yrbl-mlyw).
+	normalisedFields = normalisedFields[:len(normalisedFields):len(normalisedFields)]
 	return normalisedFields, nil
 }


### PR DESCRIPTION
## Problem

`normaliseFields` allocates its output slice with `cap = len(input)`:

```go
normalisedFields := make(Fields, 0, len(fields))
```

When wildcard fields are filtered out (because matching concrete fields exist), the returned slice has `len < cap`. The surplus capacity is a latent data-race vector: any caller that shares this slice across goroutines and later appends to it can write into backing-array slots that other goroutines are concurrently reading or writing, without Go's runtime detecting a conflict at the slice-header level.

This is the underlying condition that enables the data race fixed in `newGeneratorWithCustomTemplate` — but it affects **all callers** of `normaliseFields`, not just that function.

## Fix

Add a three-index slice expression before returning to trim the excess:

```go
normalisedFields = normalisedFields[:len(normalisedFields):len(normalisedFields)]
return normalisedFields, nil
```

With `cap == len`, any subsequent `append` by a caller **must** allocate a fresh backing array and cannot interfere with other users of the same slice. This is a standard Go idiom for returning a slice that is safe to append to from multiple goroutines without additional synchronisation.