### PR TITLE
fix: resolve leaf type for flattened/object sub-key fields in template generation

### DIFF
--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -129,10 +129,8 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int, st
 					}
 				}
 
-				// Build the sub-key field with the resolved leaf type so that
-				// bindField uses bindKeyword directly rather than recursing
-				// through bindObject → bindDynamicObject with Type = "flattened"
-				// (which could wrap a nil emitter under race conditions).
+				// Resolve the leaf type so bindField binds the sub-key directly
+				// (e.g. keyword/long) instead of re-entering bindObject → bindDynamicObject.
 				subKeyField := field
 				subKeyField.Name = fieldNameRoot + "." + rNoun
 				if subKeyField.ObjectType != "" {

--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -129,10 +129,18 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int, st
 					}
 				}
 
-				originalFieldName := field.Name
-				field.Name = fieldNameRoot + "." + rNoun
-				objectKeysField = append(objectKeysField, field)
-				field.Name = originalFieldName
+				// Build the sub-key field with the resolved leaf type so that
+				// bindField uses bindKeyword directly rather than recursing
+				// through bindObject → bindDynamicObject with Type = "flattened"
+				// (which could wrap a nil emitter under race conditions).
+				subKeyField := field
+				subKeyField.Name = fieldNameRoot + "." + rNoun
+				if subKeyField.ObjectType != "" {
+					subKeyField.Type = subKeyField.ObjectType
+				} else {
+					subKeyField.Type = FieldTypeKeyword
+				}
+				objectKeysField = append(objectKeysField, subKeyField)
 
 				templateBuffer.WriteString(fieldTemplate)
 			}


### PR DESCRIPTION
## Problem

In `generateTemplateFromField`, when a `flattened`, `object`, or `nested` field generates random sub-key entries (`objectKeysField`), each sub-key was built by mutating the parent field in-place:

```go
originalFieldName := field.Name
field.Name = fieldNameRoot + "." + rNoun
objectKeysField = append(objectKeysField, field)
field.Name = originalFieldName
```

Each appended entry therefore **inherits the parent's `Type`** (e.g. `"flattened"`). When `bindField` processes such an entry it routes through `bindObject → bindDynamicObject` instead of `bindKeyword` directly. `bindObject` resets the type to `keyword` before delegating, so the final emitter is correct — but the extra indirection is unnecessary, obscures intent, and creates an avoidable wrapper layer around the emitter.

There is also a subtle mutation hazard: if `field` is later referenced again in the same loop iteration after the restore (`field.Name = originalFieldName`), the temporary name change could in principle produce unexpected side effects.

## Fix

Copy the field into a new variable and resolve the leaf type before appending:

```go
subKeyField := field
subKeyField.Name = fieldNameRoot + "." + rNoun
if subKeyField.ObjectType != "" {
    subKeyField.Type = subKeyField.ObjectType
} else {
    subKeyField.Type = FieldTypeKeyword
}
objectKeysField = append(objectKeysField, subKeyField)
```

- The original `field` is no longer mutated.
- Sub-keys receive the correct leaf type so `bindField` calls `bindKeyword` directly, matching the semantic intent.