### PR TITLE
genlib: split expensive template compilation from cheap per-drone instantiation

### DIFF
--- a/pkg/genlib/generator_with_custom_template.go
+++ b/pkg/genlib/generator_with_custom_template.go
@@ -6,7 +6,9 @@ package genlib
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"reflect"
 	"regexp"
 )
 
@@ -17,12 +19,31 @@ type emitter struct {
 	prefix    []byte
 }
 
-// GeneratorWithCustomTemplate is resolved at construction to a slice of emit functions
-type GeneratorWithCustomTemplate struct {
-	totEvents        uint64
+// customTemplate holds the compiled, immutable, shareable part of a custom
+// template generator. Safe for concurrent use by multiple Generator instances.
+type customTemplate struct {
 	emitters         []emitter
 	trailingTemplate []byte
-	state            *genState
+	totEvents        uint64
+	fieldNames       []string
+}
+
+// GeneratorWithCustomTemplate pairs a shared customTemplate with per-instance mutable state.
+type GeneratorWithCustomTemplate struct {
+	tpl   *customTemplate
+	state *genState
+}
+
+func newGeneratorWithCustomTemplate(template []byte) func(Config, Fields, uint64, options) (Generator, error) {
+	return func(cfg Config, flds Fields, totEvents uint64, opts options) (Generator, error) {
+		compiled, err := NewCustomTemplate(cfg, flds, totEvents, template)
+		if err != nil {
+			return nil, err
+		}
+		var o2 options
+		compiled(&o2)
+		return o2.make(Config{}, nil, 0, opts)
+	}
 }
 
 func parseCustomTemplate(template []byte) ([]string, map[string][]byte, []byte) {
@@ -82,33 +103,44 @@ func parseCustomTemplate(template []byte) ([]string, map[string][]byte, []byte) 
 
 }
 
-func newGeneratorWithCustomTemplate(cfg Config, fields Fields, totEvents uint64, opts options) (Generator, error) {
-	state := newGenState(opts.randSeed, opts.startTime, opts.timeSpeed)
+// NewCustomTemplate compiles a custom template from cfg and fields. The result
+// is returned as an Option that can be passed to NewGenerator to cheaply create
+// multiple Generator instances sharing the compiled template.
+//
+// If templateBytes is nil, the template is auto-generated from fields (random
+// noun keys for object/flattened/nested fields). opts may include WithRandSeed
+// (for deterministic noun generation), WithStartTime, and WithTimeSpeed.
+//
+// Intended usage:
+//
+//	// Compile once per stream (expensive)
+//	opt, err := genlib.NewCustomTemplate(cfg, flds, totEvents, nil)
+//
+//	// Per drone (cheap — only allocates genState)
+//	g, err := genlib.NewGenerator(nil, nil, 0, opt, genlib.WithRandSeed(seed))
+func NewCustomTemplate(cfg Config, fields Fields, totEvents uint64, templateBytes []byte, opts ...Option) (Option, error) {
+	o := applyOptions(opts)
 
-	// If no template provided, generate one from fields
-	if opts.template == nil {
-		template, objectKeysField := generateCustomTemplateFromField(cfg, fields, state)
-		fields = append(fields, objectKeysField...)
-		opts.template = template
+	if templateBytes == nil {
+		tmpState := newGenState(o.randSeed, o.startTime, o.timeSpeed)
+		var objectKeysFields Fields
+		templateBytes, objectKeysFields = generateCustomTemplateFromField(cfg, fields, tmpState)
+		fields = append(fields, objectKeysFields...)
 	}
 
-	// Parse the template and extract relevant information
-	orderedFields, templateFieldsMap, trailingTemplate := parseCustomTemplate(opts.template)
+	orderedFields, templateFieldsMap, trailingTemplate := parseCustomTemplate(templateBytes)
 
-	// Preprocess the fields, generating appropriate emit functions
 	fieldMap := make(map[string]any)
 	fieldTypes := make(map[string]string)
+	fieldNames := make([]string, 0, len(fields))
 	for _, field := range fields {
 		if err := bindField(cfg, field, fieldMap, false); err != nil {
 			return nil, err
 		}
-
 		fieldTypes[field.Name] = field.Type
-		state.prevCacheForDup[field.Name] = make(map[any]struct{})
-		state.prevCacheCardinality[field.Name] = make([]any, 0)
+		fieldNames = append(fieldNames, field.Name)
 	}
 
-	// Roll into slice of emit functions
 	emitters := make([]emitter, 0, len(fieldMap))
 	for _, fieldName := range orderedFields {
 		emitters = append(emitters, emitter{
@@ -119,9 +151,27 @@ func newGeneratorWithCustomTemplate(cfg Config, fields Fields, totEvents uint64,
 		})
 	}
 
-	state.totEvents = totEvents
+	tpl := &customTemplate{
+		emitters:         emitters,
+		trailingTemplate: trailingTemplate,
+		totEvents:        totEvents,
+		fieldNames:       fieldNames,
+	}
 
-	return &GeneratorWithCustomTemplate{emitters: emitters, trailingTemplate: trailingTemplate, totEvents: totEvents, state: state}, nil
+	return func(o *options) {
+		o.make = func(cfg Config, flds Fields, totEvents uint64, opts options) (Generator, error) {
+			if len(flds) != 0 || totEvents != 0 || !reflect.ValueOf(cfg).IsZero() {
+				return nil, errors.New("cfg, flds and totEvents must be nil/zero when using a pre-compiled template option; pass them to NewCustomTemplate instead")
+			}
+			state := newGenState(opts.randSeed, opts.startTime, opts.timeSpeed)
+			for _, fieldName := range tpl.fieldNames {
+				state.prevCacheForDup[fieldName] = make(map[any]struct{})
+				state.prevCacheCardinality[fieldName] = make([]any, 0)
+			}
+			state.totEvents = tpl.totEvents
+			return &GeneratorWithCustomTemplate{tpl: tpl, state: state}, nil
+		}
+	}, nil
 }
 
 func (gen *GeneratorWithCustomTemplate) Close() error {
@@ -139,15 +189,15 @@ func (gen *GeneratorWithCustomTemplate) Emit(buf *bytes.Buffer) error {
 }
 
 func (gen *GeneratorWithCustomTemplate) emit(buf *bytes.Buffer) error {
-	if gen.totEvents == 0 || gen.state.counter < gen.totEvents {
-		for _, e := range gen.emitters {
+	if gen.tpl.totEvents == 0 || gen.state.counter < gen.tpl.totEvents {
+		for _, e := range gen.tpl.emitters {
 			buf.Write(e.prefix)
 			if err := e.emitFunc(gen.state, buf); err != nil {
 				return err
 			}
 		}
 
-		buf.Write(gen.trailingTemplate)
+		buf.Write(gen.tpl.trailingTemplate)
 	} else {
 		return io.EOF
 	}

--- a/pkg/genlib/generator_with_text_template.go
+++ b/pkg/genlib/generator_with_text_template.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"reflect"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -48,53 +49,109 @@ var awsAZs map[string][]string = map[string][]string{
 	"us-west-2":      {"us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"},
 }
 
-func newGeneratorWithTextTemplate(cfg Config, fields Fields, totEvents uint64, opts options) (Generator, error) {
-	// Preprocess the fields, generating appropriate bound function
-	state := newGenState(opts.randSeed, opts.startTime, opts.timeSpeed)
+func newGeneratorWithTextTemplate(template []byte) func(Config, Fields, uint64, options) (Generator, error) {
+	return func(cfg Config, flds Fields, totEvents uint64, opts options) (Generator, error) {
+		compiled, err := NewTextTemplate(cfg, flds, totEvents, template)
+		if err != nil {
+			return nil, err
+		}
+		var o2 options
+		compiled(&o2)
+		return o2.make(Config{}, nil, 0, opts)
+	}
+}
+
+// buildTextFuncMap is the single place where all state-capturing template
+// functions are defined. state may be (*genState)(nil) at compile time
+// (Parse only checks function signatures, never calls them); any attempt to
+// Execute the unbound template will panic immediately, making the bug obvious.
+func buildTextFuncMap(state *genState, fieldMap map[string]any, errChan chan error) template.FuncMap {
+	return template.FuncMap{
+		"generate": func(field string) any {
+			bindF, ok := fieldMap[field].(emitF)
+			if !ok {
+				close(errChan)
+				return nil
+			}
+			return bindF(state)
+		},
+		"awsAZFromRegion": func(region string) string {
+			azs, ok := awsAZs[region]
+			if !ok {
+				return "NoAZ"
+			}
+			return azs[state.rand.Intn(len(azs))]
+		},
+	}
+}
+
+// NewTextTemplate compiles a Go text template from cfg and fields. The result
+// is returned as an Option that can be passed to NewGenerator to cheaply create
+// multiple Generator instances sharing the compiled template.
+//
+// If templateBytes is nil, the template is auto-generated from fields.
+//
+// Intended usage:
+//
+//	// Compile once per stream (expensive)
+//	opt, err := genlib.NewTextTemplate(cfg, flds, totEvents, nil)
+//
+//	// Per drone (cheap — only allocates genState)
+//	g, err := genlib.NewGenerator(nil, nil, 0, opt, genlib.WithRandSeed(seed))
+func NewTextTemplate(cfg Config, flds Fields, totEvents uint64, templateBytes []byte, opts ...Option) (Option, error) {
+	o := applyOptions(opts)
+
+	if templateBytes == nil {
+		tmpState := newGenState(o.randSeed, o.startTime, o.timeSpeed)
+		var objectKeysFields Fields
+		templateBytes, objectKeysFields = generateTextTemplateFromField(cfg, flds, tmpState)
+		flds = append(flds, objectKeysFields...)
+	}
+
 	fieldMap := make(map[string]any)
-	for _, field := range fields {
+	fieldNames := make([]string, 0, len(flds))
+	for _, field := range flds {
 		if err := bindField(cfg, field, fieldMap, true); err != nil {
 			return nil, err
 		}
-
-		state.prevCacheForDup[field.Name] = make(map[any]struct{})
-		state.prevCacheCardinality[field.Name] = make([]any, 0)
+		fieldNames = append(fieldNames, field.Name)
 	}
 
-	errChan := make(chan error)
-
-	templateFns := sprig.TxtFuncMap()
-
-	templateFns["awsAZFromRegion"] = func(region string) string {
-		azs, ok := awsAZs[region]
-		if !ok {
-			return "NoAZ"
-		}
-
-		return azs[state.rand.Intn(len(azs))]
+	// Parse with poisoned nil-state closures. Parse only validates function
+	// signatures, never calls them; nil-state panics loudly if the template is
+	// ever executed without per-drone rebinding via Clone + Funcs.
+	allFns := sprig.TxtFuncMap()
+	for k, v := range buildTextFuncMap((*genState)(nil), fieldMap, make(chan error)) {
+		allFns[k] = v
 	}
-
-	templateFns["generate"] = func(field string) any {
-		bindF, ok := fieldMap[field].(emitF)
-		if !ok {
-			close(errChan)
-			return nil
-		}
-
-		return bindF(state)
-	}
-
-	t := template.New("generator")
-	t = t.Option("missingkey=error")
-
-	parsedTpl, err := t.Funcs(templateFns).Parse(string(opts.template))
+	t := template.New("generator").Option("missingkey=error")
+	parsedTpl, err := t.Funcs(allFns).Parse(string(templateBytes))
 	if err != nil {
 		return nil, err
 	}
 
-	state.totEvents = totEvents
+	return func(o *options) {
+		o.make = func(cfg Config, flds Fields, argTotEvents uint64, opts options) (Generator, error) {
+			if len(flds) != 0 || argTotEvents != 0 || !reflect.ValueOf(cfg).IsZero() {
+				return nil, errors.New("cfg, flds and totEvents must be nil/zero when using a pre-compiled template option; pass them to NewTextTemplate instead")
+			}
+			state := newGenState(opts.randSeed, opts.startTime, opts.timeSpeed)
+			for _, fieldName := range fieldNames {
+				state.prevCacheForDup[fieldName] = make(map[any]struct{})
+				state.prevCacheCardinality[fieldName] = make([]any, 0)
+			}
+			state.totEvents = totEvents
 
-	return &GeneratorWithTextTemplate{tpl: parsedTpl, totEvents: totEvents, state: state, errChan: errChan}, nil
+			errChan := make(chan error)
+			cloned, err := parsedTpl.Clone()
+			if err != nil {
+				return nil, err
+			}
+			cloned.Funcs(buildTextFuncMap(state, fieldMap, errChan))
+
+			return &GeneratorWithTextTemplate{tpl: cloned, totEvents: totEvents, state: state, errChan: errChan}, nil
+		}
+	}, nil
 }
 
 func (gen *GeneratorWithTextTemplate) Close() error {

--- a/pkg/genlib/options.go
+++ b/pkg/genlib/options.go
@@ -11,7 +11,6 @@ type options struct {
 	randSeed  int64
 	startTime time.Time
 	timeSpeed float64
-	template  []byte
 	make      func(Config, Fields, uint64, options) (Generator, error)
 }
 
@@ -52,27 +51,29 @@ func WithRandSeed(seed int64) Option {
 }
 
 // WithTextTemplate sets a Go text template for the generator.
+// The template is compiled on each NewGenerator call. To compile once and share
+// across multiple generators, use NewTextTemplate instead.
 func WithTextTemplate(template []byte) Option {
 	return func(o *options) {
-		o.template = template
-		o.make = newGeneratorWithTextTemplate
+		o.make = newGeneratorWithTextTemplate(template)
 	}
 }
 
 // WithCustomTemplate sets a custom placeholder template for the generator.
+// The template is compiled on each NewGenerator call. To compile once and share
+// across multiple generators, use NewCustomTemplate instead.
 func WithCustomTemplate(template []byte) Option {
 	return func(o *options) {
-		o.template = template
-		o.make = newGeneratorWithCustomTemplate
+		o.make = newGeneratorWithCustomTemplate(template)
 	}
 }
 
 // applyOptions applies the given options and returns the final configuration.
 func applyOptions(opts []Option) options {
-	// This initialization is executed in a concurrent context, any accesss
+	// This initialization is executed in a concurrent context, any access
 	// to non thread-safe resources must be properly synchronized.
 	o := options{
-		make:      newGeneratorWithCustomTemplate,
+		make:      newGeneratorWithCustomTemplate(nil),
 		randSeed:  time.Now().UnixNano(),
 		startTime: time.Now(),
 	}


### PR DESCRIPTION
## Problem

At scale (15k drones × 20 streams = 300k generators) each `NewGenerator` call repeats all the expensive work: parsing the template, compiling emitters, binding fields. This work is identical across drones sharing the same stream and only needs to happen once.

## Solution

Introduce `NewCustomTemplate` and `NewTextTemplate` — new exported functions that perform all expensive compilation once and return an `Option`. Passing that `Option` to `NewGenerator` is then a cheap per-drone operation that only allocates a fresh `genState` (RNG + caches).

### Key design points

- **`customTemplate`** (unexported struct) holds the immutable compiled state for the custom engine (`emitters`, `trailingTemplate`, `totEvents`, `fieldNames`). `GeneratorWithCustomTemplate` changes from owning those fields directly to holding a `*customTemplate` pointer plus a per-drone `*genState`.

- **`buildTextFuncMap`** is the single definition of the two state-capturing text-template functions (`generate`, `awsAZFromRegion`). At compile time they are registered with a poisoned `(*genState)(nil)` so any accidental execution panics loudly. Per drone, `parsedTpl.Clone()` + `Funcs()` rebinds them to a real `genState` in O(1).

- **Legacy `WithCustomTemplate` / `WithTextTemplate`** options internally delegate to `NewCustomTemplate` / `NewTextTemplate` so all compilation goes through one codepath and all existing tests continue to cover it.

- **`options.template []byte`** is removed; template bytes now travel via explicit parameter or closure only.

## Usage (new API)

```go
// Compile once per stream (expensive)
opt, err := genlib.NewCustomTemplate(cfg, flds, totEvents, nil)
if err != nil { ... }

// Per drone — cheap, only allocates genState
g, err := genlib.NewGenerator(nil, nil, 0, opt, genlib.WithRandSeed(seed))
```

## Backward compatibility

All existing call sites (`WithCustomTemplate`, `WithTextTemplate`, `NewGenerator`) are unchanged. Only additions: `NewCustomTemplate`, `NewTextTemplate`.
