### PR TITLE
Fix alias fields in generated documents

### DIFF
--- a/pkg/genlib/generator.go
+++ b/pkg/genlib/generator.go
@@ -58,6 +58,7 @@ func generateTextTemplateFromField(cfg Config, fields Fields, state *genState) (
 }
 
 func generateTemplateFromField(cfg Config, fields Fields, templateEngine int, state *genState) ([]byte, []Field) {
+	fields = writableFields(fields)
 	if len(fields) == 0 {
 		return nil, nil
 	}
@@ -159,6 +160,19 @@ func generateTemplateFromField(cfg Config, fields Fields, templateEngine int, st
 	}
 
 	return templateBuffer.Bytes(), objectKeysField
+}
+
+// writableFields returns the fields that may be written into an Elasticsearch
+// document. Alias fields are query-time paths and Elasticsearch rejects
+// documents that contain a value for them.
+func writableFields(fields Fields) Fields {
+	result := make(Fields, 0, len(fields))
+	for _, field := range fields {
+		if field.Type != FieldTypeAlias {
+			result = append(result, field)
+		}
+	}
+	return result
 }
 
 // NewGenerator creates a new generator that auto-generates a custom template from fields.

--- a/pkg/genlib/generator_interface.go
+++ b/pkg/genlib/generator_interface.go
@@ -49,6 +49,7 @@ const (
 	FieldTypeNested          = "nested"
 	FieldTypeFlattened       = "flattened"
 	FieldTypeGeoPoint        = "geo_point"
+	FieldTypeAlias           = "alias"
 
 	FieldTypeDurationSpan = 1000 // milliseconds
 	FieldTypeTimeLayout   = "2006-01-02T15:04:05.999999Z07:00"

--- a/pkg/genlib/generator_test.go
+++ b/pkg/genlib/generator_test.go
@@ -39,6 +39,28 @@ func Benchmark_GeneratorCustomTemplateJSONContent(b *testing.B) {
 	}
 }
 
+func TestGeneratedTemplatesSkipAliasFields(t *testing.T) {
+	fields := Fields{
+		{Name: "event.dataset", Type: FieldTypeKeyword},
+		{Name: "cluster_uuid", Type: FieldTypeAlias},
+	}
+
+	for name, generate := range map[string]func(Config, Fields, *genState) ([]byte, []Field){
+		"custom": generateCustomTemplateFromField,
+		"text":   generateTextTemplateFromField,
+	} {
+		t.Run(name, func(t *testing.T) {
+			template, _ := generate(Config{}, fields, newGenState(1, time.Now(), 0))
+			if bytes.Contains(template, []byte("cluster_uuid")) {
+				t.Fatalf("generated template contains read-only alias field: %s", template)
+			}
+			if !bytes.Contains(template, []byte("event.dataset")) {
+				t.Fatalf("generated template omits writable field: %s", template)
+			}
+		})
+	}
+}
+
 func Benchmark_GeneratorTextTemplateJSONContent(b *testing.B) {
 	ctx := context.Background()
 	flds, _, err := fields.LoadFields(ctx, fields.ProductionBaseURL, "endpoint", "process", "8.2.0")


### PR DESCRIPTION
Relates to #48 (aliases).

Alias fields are query-time paths and Elasticsearch rejects documents that contain values for them. Exclude aliases while automatically generating custom and text templates, and cover both paths with a regression test.